### PR TITLE
Patch to fix unicode casting error with postgres 8.4 and django 1.2.2

### DIFF
--- a/zinnia/templatetags/zinnia_tags.py
+++ b/zinnia/templatetags/zinnia_tags.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from django.template import Library
 from django.contrib.comments.models import Comment
 from django.contrib.contenttypes.models import ContentType
+from django.utils.encoding import smart_unicode
 
 from zinnia.models import Entry
 from zinnia.models import Category
@@ -158,7 +159,7 @@ def get_calendar_entries(context, year=None, month=None,
 @register.inclusion_tag('zinnia/tags/dummy.html')
 def get_recent_comments(number=5, template='zinnia/tags/recent_comments.html'):
     """Return the most recent comments"""
-    entry_published_pks = Entry.published.values_list('id', flat=True)
+    entry_published_pks = [smart_unicode(e) for e in Entry.published.values_list('id', flat=True)]
     ct = ContentType.objects.get_for_model(Entry)
 
     comments = Comment.objects.filter(


### PR DESCRIPTION
Without this fix, I get this error when trying to run zinnia:

```
Template error

In template <my-virtualenv>/site-packages/django_blog_zinnia-0.6-py2.7.egg/zinnia/templates/zinnia/tags/recent_comments.html, error at line 4
Caught DatabaseError while rendering: operator does not exist: text = integer LINE 1: ...comment_id") WHERE ("django_comments"."object_pk" IN (SELECT... ^ HINT: No operator matches the given name and argument type(s). You might need to add explicit type casts.
```

Some research showed this error to be related to this ticket: http://code.djangoproject.com/ticket/8554 . So I converted the entry pks using smart_unicode, and bam everything worked.
