### PR TITLE
Query optimization of authors who published an entry

### DIFF
--- a/zinnia/managers.py
+++ b/zinnia/managers.py
@@ -20,7 +20,7 @@ def tags_published():
 def authors_published():
     """Return the published authors"""
     from django.contrib.auth.models import User
-    return User.objects.filter(entry__status=2).distinct()
+    return User.objects.filter(entry__status=PUBLISHED).distinct()
 
 def entries_published(queryset):
     """Return only the entries published"""


### PR DESCRIPTION
If zinnia is used in an environment with a lot of users this query could get very very slow :) Recognized that, after i've imported more than 10000 users into a django project that also uses zinnia.
