### PR TITLE
Default for  'sites' in admin

### DIFF
--- a/zinnia/admin/forms.py
+++ b/zinnia/admin/forms.py
@@ -9,6 +9,7 @@ from zinnia.models import Entry
 from zinnia.models import Category
 from zinnia.admin.widgets import TreeNodeChoiceField
 from zinnia.admin.widgets import MPTTFilteredSelectMultiple
+from django.contrib.sites.models import Site
 from zinnia.admin.widgets import MPTTModelMultipleChoiceField
 
 
@@ -51,6 +52,8 @@ class EntryAdminForm(forms.ModelForm):
         rel = ManyToManyRel(Category, 'id')
         self.fields['categories'].widget = RelatedFieldWidgetWrapper(
             self.fields['categories'].widget, rel, self.admin_site)
+        self.fields['sites'].initial = [Site.objects.get_current()]
+
 
     class Meta:
         """EntryAdminForm's Meta"""


### PR DESCRIPTION
I think it's pretty nasty to always have to select which site to publish the article on, even if there's only one. I think it's a good choice to have the current selected by default. An option would be to only do this if you have exactly one site in the system...
