### PR TITLE
Permanent redirect on trackback

### DIFF
--- a/zinnia/views/trackback.py
+++ b/zinnia/views/trackback.py
@@ -42,4 +42,4 @@ def entry_trackback(request, slug):
                                   mimetype='text/xml',
                                   extra_context={'error': error})
 
-    return redirect(entry)
+    return redirect(entry, permanent=True)


### PR DESCRIPTION
Trivial commit to change the redirect on the trackbacks.

Being permanent, we force the search engines to index the valid page
