### PR TITLE
Fixing cirular import

### DIFF
--- a/zinnia/plugins/settings.py
+++ b/zinnia/plugins/settings.py
@@ -1,16 +1,24 @@
 """Settings of Zinnia.plugins"""
 from django.conf import settings
+import sys 
 
 HIDE_ENTRY_MENU = getattr(settings, 'ZINNIA_HIDE_ENTRY_MENU', True)
 
 PLUGINS_TEMPLATES = getattr(settings, 'ZINNIA_PLUGINS_TEMPLATES', [])
 try:
-    from zinnia.plugins.menu import EntryMenu
-    from zinnia.plugins.menu import TagMenu
-    from zinnia.plugins.menu import AuthorMenu
-    from zinnia.plugins.menu import CategoryMenu
 
-    APP_MENUS = getattr(settings, 'ZINNIA_APP_MENUS', [EntryMenu, CategoryMenu,
-                                                       TagMenu, AuthorMenu])
+    APP_STRING_LIST = getattr(settings, 'ZINNIA_APP_MENUS', ["EntryMenu", "CategoryMenu",
+                                                       "TagMenu", "AuthorMenu"])
+    APP_MENUS = []
+    for app_string in APP_STRING_LIST:
+        if "." in app_string:
+            __import__(".".join(app_string.split(".")[:-1]), globals(), locals())
+            module = sys.modules[".".join(app_string.split(".")[:-1])]
+            app = app_string.split(".")[-1]
+        else:
+            from zinnia.plugins import menu
+            app = app_string
+            module = menu
+        APP_MENUS.append(getattr(module, app))
 except ImportError:
     APP_MENUS = []


### PR DESCRIPTION
Fixing a circular import when trying to override default ZINNIA_APP_MENUS in main settings.py.

I could not override the ZINNIA_APP_MENUS setting in the django.conf.settings because I must import the classes from zinnia.plugins.menu and that was a circular import.

I modified the code to use a list of strings instead a list of classes. If you provide a full class name such as 'zinnia.plugins.menu.TagEntry' it imports the module, and construct the class list. If you just provide a class name (not points in the string) it assume is a class defined in 'zinnia.plugins.menu'.
