### PR TITLE
Correct base meta class name

### DIFF
--- a/docs/how-to/extending_entry_model.rst
+++ b/docs/how-to/extending_entry_model.rst
@@ -39,7 +39,7 @@ Example for adding a gallery field. ::
   class EntryGallery(EntryAbstractClass):
     gallery = models.ForeignKey(Gallery)
 
-    class Meta(EntryAbstract.Meta):
+    class Meta(EntryAbstractClass.Meta):
       abstract = True
 
 


### PR DESCRIPTION
Fixes a typo in the documentation
