### PR TITLE
Fix `rel="archives"` : won't pass w3c validator today

### DIFF
--- a/zinnia/templates/zinnia/entry_archive_day.html
+++ b/zinnia/templates/zinnia/entry_archive_day.html
@@ -14,11 +14,11 @@
 
 <!--<ul>
   <li>
-    <a href="{% url zinnia_entry_archive_day previous_day|date:"Y" previous_day|date:"m" previous_day|date:"d" %}" rel="archives">{{ previous_day|date:"DATE_FORMAT" }}</a>
+    <a href="{% url zinnia_entry_archive_day previous_day|date:"Y" previous_day|date:"m" previous_day|date:"d" %}">{{ previous_day|date:"DATE_FORMAT" }}</a>
   </li>
   {% if next_day %}
   <li>
-    <a href="{% url zinnia_entry_archive_day next_day|date:"Y" next_day|date:"m" next_day|date:"d" %}" rel="archives">{{ next_day|date:"DATE_FORMAT" }}</a>
+    <a href="{% url zinnia_entry_archive_day next_day|date:"Y" next_day|date:"m" next_day|date:"d" %}">{{ next_day|date:"DATE_FORMAT" }}</a>
   </li>
   {% endif %}
 </ul>-->

--- a/zinnia/templates/zinnia/entry_archive_month.html
+++ b/zinnia/templates/zinnia/entry_archive_month.html
@@ -16,17 +16,17 @@
 <ul>
   {% for date in date_list %}
   <li>
-    <a href="{% url zinnia_entry_archive_day date|date:"Y" date|date:"m" date|date:"d" %}" rel="archives">{{ date|date:"DATE_FORMAT" }}</a>
+    <a href="{% url zinnia_entry_archive_day date|date:"Y" date|date:"m" date|date:"d" %}">{{ date|date:"DATE_FORMAT" }}</a>
   </li>
   {% endfor %}
 </ul>
 <!--<ul>
   <li>
-    <a href="{% url zinnia_entry_archive_month previous_month|date:"Y" previous_month|date:"m" %}" rel="archives">{{ previous_month|date:"YEAR_MONTH_FORMAT" }}</a>
+    <a href="{% url zinnia_entry_archive_month previous_month|date:"Y" previous_month|date:"m" %}">{{ previous_month|date:"YEAR_MONTH_FORMAT" }}</a>
   </li>
   {% if next_month %}
   <li>
-    <a href="{% url zinnia_entry_archive_month next_month|date:"Y" next_month|date:"m" %}" rel="archives">{{ next_month|date:"YEAR_MONTH_FORMAT" }}</a>
+    <a href="{% url zinnia_entry_archive_month next_month|date:"Y" next_month|date:"m" %}">{{ next_month|date:"YEAR_MONTH_FORMAT" }}</a>
   </li>
   {% endif %}
 </ul>-->

--- a/zinnia/templates/zinnia/entry_archive_year.html
+++ b/zinnia/templates/zinnia/entry_archive_year.html
@@ -16,7 +16,7 @@
 <ul>
   {% for date in date_list %}
   <li>
-    <a href="{% url zinnia_entry_archive_month year date|date:"m" %}" rel="archives">{{ date|date:"YEAR_MONTH_FORMAT" }}</a>
+    <a href="{% url zinnia_entry_archive_month year date|date:"m" %}">{{ date|date:"YEAR_MONTH_FORMAT" }}</a>
   </li>
   {% endfor %}
 </ul>

--- a/zinnia/templates/zinnia/tags/archives_entries.html
+++ b/zinnia/templates/zinnia/tags/archives_entries.html
@@ -2,7 +2,7 @@
 <ul>
   {% for date in archives %}
   <li>
-    <a title="{% trans "Archives" %} {{ date|date:"YEAR_MONTH_FORMAT" }}" rel="archives"
+    <a title="{% trans "Archives" %} {{ date|date:"YEAR_MONTH_FORMAT" }}"
        href="{% url zinnia_entry_archive_month date|date:"Y" date|date:"m" %}">
       {{ date|date:"YEAR_MONTH_FORMAT" }}
     </a>

--- a/zinnia/templates/zinnia/tags/archives_entries_link.html
+++ b/zinnia/templates/zinnia/tags/archives_entries_link.html
@@ -1,3 +1,3 @@
 {% load i18n %}
-{% for date in archives %}<link rel="archives" title="{% trans "Archives" %} {{ date|date:"YEAR_MONTH_FORMAT" }}" href="{% url zinnia_entry_archive_month date|date:"Y" date|date:"m" %}" />
+{% for date in archives %}<link title="{% trans "Archives" %} {{ date|date:"YEAR_MONTH_FORMAT" }}" href="{% url zinnia_entry_archive_month date|date:"Y" date|date:"m" %}" />
 {% endfor %}

--- a/zinnia/templates/zinnia/tags/archives_entries_tree.html
+++ b/zinnia/templates/zinnia/tags/archives_entries_tree.html
@@ -3,14 +3,14 @@
 <ul>
   {% for year in year_list %}
   <li>
-    <a title="{% trans "Archives" %} {{ year.grouper }}" rel="archives"
+    <a title="{% trans "Archives" %} {{ year.grouper }}"
        href="{% url zinnia_entry_archive_year year.grouper %}">{{ year.grouper }}</a>
     {% regroup year.list by month as month_list %}
     <ul>
       {% for month in month_list %}
       <li>
         {% with month_date=month.list.0 %}
-        <a title="{% trans "Archives" %} {{ month_date|date:"YEAR_MONTH_FORMAT" }}" rel="archives"
+        <a title="{% trans "Archives" %} {{ month_date|date:"YEAR_MONTH_FORMAT" }}"
            href="{% url zinnia_entry_archive_month month_date|date:"Y" month_date|date:"m" %}">
           {{ month_date|date:"F" }}
         </a>
@@ -20,7 +20,7 @@
           {% for day in day_list %}
           <li>
             {% with day_date=day.list.0 %}
-            <a title="{% trans "Archives" %} {{ day_date|date:"DATE_FORMAT" }}" rel="archives"
+            <a title="{% trans "Archives" %} {{ day_date|date:"DATE_FORMAT" }}"
                href="{% url zinnia_entry_archive_day day_date|date:"Y" day_date|date:"m" day_date|date:"d" %}">
               {{ day_date|date:"MONTH_DAY_FORMAT" }}
             </a>

--- a/zinnia/templatetags/zcalendar.py
+++ b/zinnia/templatetags/zcalendar.py
@@ -31,8 +31,7 @@ class ZinniaCalendar(HTMLCalendar):
                                       args=[day_date.strftime('%Y'),
                                             day_date.strftime('%m'),
                                             day_date.strftime('%d')])
-            return '<td class="%s entry"><a href="%s" '\
-                   'rel="archives">%d</a></td>' % (
+            return '<td class="%s entry"><a href="%s">%d</a></td>' % (
                 self.cssclasses[weekday], archive_day_url, day)
 
         return super(ZinniaCalendar, self).formatday(day, weekday)


### PR DESCRIPTION
When I try to validate a Zinnia's powered blog, it fail because of `rel="archive"` now.

```
Bad value archives for attribute rel on element a: Keyword archives is not registered.
```

Also, I've tried to make my own templates based on zinnia's templates, but the templatetag zcalendar make this thing impossible because of the html embebded. So I make this patch for `rel="archive"`
