### PR TITLE
Link button/command creates incorrect reStructuredText markup.

### DIFF
--- a/zinnia/static/zinnia/js/markitup/sets/restructuredtext/set.js
+++ b/zinnia/static/zinnia/js/markitup/sets/restructuredtext/set.js
@@ -28,7 +28,7 @@ mySettings = {
 		{name:'Numeric list', openWith:'# '},
 		{separator:'---------------' },
 		{name:'Picture', key:'P', openWith:'\n\n.. image:: ', closeWith:'\n\n', placeHolder:'Your picture here...'},
-		{name:'Link', key:'L', openWith:'`', closeWith:' [![Link:!:http://]!]`_', placeHolder:'Your text to link here...'},
+		{name:'Link', key:'L', openWith:'`', closeWith:' <[![Link:!:http://]!]>`_', placeHolder:'Your text to link here...'},
 		{separator:'---------------'},
 		{name:'Quote', openWith:'\t'},
 		{name:'Code', openWith:'``', closeWith:'``'},


### PR DESCRIPTION
Attempting to use the link button to create a link for RST posts will currently yield messages like "Unknown target name&hellip;" See http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#embedded-uris for the correct syntax.

See also the corresponding change in Florent's mercurial repo:
https://bitbucket.org/fgallaire/rest-markitup/changeset/71f0730239726447f4c4d2840d28d38eeaa50574
