### PR TITLE
EntryPublishedManager.on_site doesn't return only published entries

### DIFF
--- a/zinnia/managers.py
+++ b/zinnia/managers.py
@@ -39,8 +39,7 @@ class EntryPublishedManager(models.Manager):
 
     def on_site(self):
         """Return entries published on current site"""
-        return super(EntryPublishedManager, self).get_query_set(
-            ).filter(sites=Site.objects.get_current())
+        return self.get_query_set().filter(sites=Site.objects.get_current())
 
     def search(self, pattern):
         """Top level search method on entries"""


### PR DESCRIPTION
Before this fix:

```
In [1]: [e.status for e in Entry.published.on_site()]
Out[1]: [2, 2, 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 2, 2, 2]
```

after this fix:

```
In [1]: [e.status for e in Entry.published.on_site()]
Out[1]: [2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]
```

Unless there's a reason for that call to `super()` that I don't know of..
