### PR TITLE
fix viewport meta tag in skeleton template

### DIFF
--- a/zinnia/templates/zinnia/skeleton.html
+++ b/zinnia/templates/zinnia/skeleton.html
@@ -8,7 +8,7 @@
     <meta http-equiv="cache-control" content="public" />
     <meta name="robots" content="follow, all" />
     <meta name="language" content="{{ LANGUAGE_CODE }}" />
-    <meta name="viewport" content="width=device-width; initial-scale=1.0;" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="{% block meta-description %}Demonstration of the Zinnia Blog application.{% endblock %}" />
     <meta name="keywords" content="{% block meta-keywords %}django, blog, zinnia{% endblock %}" />
     <meta name="author" content="Fantomas42" />


### PR DESCRIPTION
The "content" attribute is comma separated, was getting an error on chrome.
