### PR TITLE
Proper author username resolution

### DIFF
--- a/zinnia/urls/authors.py
+++ b/zinnia/urls/authors.py
@@ -12,10 +12,10 @@ urlpatterns = patterns(
     url(r'^$',
         AuthorList.as_view(),
         name='zinnia_author_list'),
-    url(r'^(?P<username>[.+-@\w]+)/$',
-        AuthorDetail.as_view(),
-        name='zinnia_author_detail'),
     url(_(r'^(?P<username>[.+-@\w]+)/page/(?P<page>\d+)/$'),
         AuthorDetail.as_view(),
         name='zinnia_author_detail_paginated'),
+    url(r'^(?P<username>[.+-@\w]+)/$',
+        AuthorDetail.as_view(),
+        name='zinnia_author_detail'),
 )


### PR DESCRIPTION
This re r'^(?P<username>[.+-@\w]+)/$' resolve username as the whole last part of URL.
Mean this:

If URL is "/blog/authors/someusername/page/23/" than username is "someusername/page/23/"

Placing paginated view URL before UNpaginated will fix the problem.
