### PR TITLE
Remove reference to adminmedia tag library.

### DIFF
--- a/zinnia/templates/admin/zinnia/app_index.html
+++ b/zinnia/templates/admin/zinnia/app_index.html
@@ -1,5 +1,5 @@
 {% extends "admin/app_index.html" %}
-{% load i18n adminmedia %}
+{% load i18n %}
 {% load url from future %}
 
 {% block extrastyle %}


### PR DESCRIPTION
The adminmedia tag library has been removed and causes the zinnia
admin to raise an exception. Since the one tag that was in
adminmedia isn't being used, it's safe to just delete the
tag library reference.
