### PR TITLE
Fix ZinniaCalendar timezone usage.

### DIFF
--- a/zinnia/templatetags/zcalendar.py
+++ b/zinnia/templatetags/zcalendar.py
@@ -2,6 +2,7 @@
 from datetime import date
 from calendar import HTMLCalendar
 
+from django.utils import timezone
 from django.utils.dates import MONTHS
 from django.utils.dates import WEEKDAYS_ABBR
 from django.utils.formats import get_format
@@ -86,10 +87,12 @@ class ZinniaCalendar(HTMLCalendar):
         new attributes computed for formatting a day, and thead/tfooter"""
         self.current_year = theyear
         self.current_month = themonth
-        self.day_entries = [entries.creation_date.day for entries in
-                            Entry.published.filter(
+        self.day_entries = [
+            timezone.localtime(entries.creation_date, timezone.get_current_timezone()).day
+            for entries in Entry.published.filter(
                                 creation_date__year=theyear,
                                 creation_date__month=themonth)]
+
 
         v = []
         a = v.append


### PR DESCRIPTION
Entries calendar was being built using UTC dates. However, fetching entries from archive seem to use local time. This caused strange behaviour when calendar renders particular day with a link (meaning there were entries posted on that day) but after following the link zinnia shows no entries (for small timezone shifts such behaviour is easily reproduced for posts near the midnight).

Proposed fix just makes ZCalendar timezone-aware when generating its days_entries.
