### PR TITLE
refined _get_user_flagger()

### DIFF
--- a/zinnia/flags.py
+++ b/zinnia/flags.py
@@ -15,7 +15,10 @@ def _get_user_flagger():
     try:
         user = User.objects.get(pk=COMMENT_FLAG_USER_ID)
     except User.DoesNotExist:
-        user = User.objects.create_user('Zinnia-Flagger')
+          try:
+              user = User.objects.get(username='Zinnia-Flagger')
+          except User.DoesNotExist:
+              user = User.objects.create_user('Zinnia-Flagger')
     return user
 
 get_user_flagger = memoize(_get_user_flagger, user_flagger_, 0)


### PR DESCRIPTION
Had a use case where COMMENT_FLAG_USER_ID was not set, and 'Zinnia-Flagger' user had already been created.  This fix prevents a the following error:

IntegrityError: duplicate key value violates unique constraint "auth_user_username_key"
DETAIL:  Key (username)=(Zinnia-Flagger) already exists.
