### PR TITLE
fix timezone support in wp2zinnia management command

### DIFF
--- a/zinnia/management/commands/wp2zinnia.py
+++ b/zinnia/management/commands/wp2zinnia.py
@@ -1,6 +1,7 @@
 """WordPress to Zinnia command module"""
 import os
 import sys
+import pytz
 from datetime import datetime
 from optparse import make_option
 from xml.etree import ElementTree as ET
@@ -259,9 +260,9 @@ class Command(LabelCommand):
         start_publication and creation_date will use the same value,
         wich is always in Wordpress $post->post_date"""
         creation_date = datetime.strptime(
-            item_node.find('{%s}post_date' % WP_NS).text, '%Y-%m-%d %H:%M:%S')
+            item_node.find('{%s}post_date_gmt' % WP_NS).text, '%Y-%m-%d %H:%M:%S')
         if settings.USE_TZ:
-            creation_date = timezone.make_aware(creation_date, timezone.utc)
+            creation_date = timezone.make_aware(creation_date, pytz.timezone('GMT'))
 
         excerpt = strip_tags(item_node.find(
             '{%sexcerpt/}encoded' % WP_NS).text)
@@ -378,10 +379,10 @@ class Command(LabelCommand):
                 return
 
             submit_date = datetime.strptime(
-                comment_node.find('{%s}comment_date' % WP_NS).text,
+                comment_node.find('{%s}comment_date_gmt' % WP_NS).text,
                 '%Y-%m-%d %H:%M:%S')
             if settings.USE_TZ:
-                submit_date = timezone.make_aware(submit_date, timezone.utc)
+                submit_date = timezone.make_aware(submit_date, pytz.timezone('GMT'))
 
             approvation = comment_node.find(
                 '{%s}comment_approved' % WP_NS).text


### PR DESCRIPTION
In the WP export, 'post_date' represents the timezone indicated by the server, and 'post_date_gmt' represents GMT (or possibly UTC) for the same time.  On import, the management command is currently using the local timestamp but UTC as the timezone with which to interpret it, making all the times off by the timezone offset.

This solution (for entries and comments) uses the gmt values and 'GMT' as the timezone when saving datetimes.
