### PR TITLE
Fix comment view valueerror

### DIFF
--- a/zinnia/views/comments.py
+++ b/zinnia/views/comments.py
@@ -23,7 +23,7 @@ class CommentSuccess(TemplateResponseMixin, View):
             try:
                 self.comment = comments.get_model().objects.get(
                     pk=request.GET['c'])
-            except ObjectDoesNotExist, ValueError:
+            except (ObjectDoesNotExist, ValueError):
                 pass
         if self.comment and self.comment.is_public:
             return HttpResponsePermanentRedirect(


### PR DESCRIPTION
If a request is made to CommentSuccess with a "c" GET param that cannot be converted into an integer, the following exception is raised:

ValueError: invalid literal for int() with base 10: 'foo'

This fix passes that exception with the same behavior as if a comment matching a certain pk was not found, so a 500 is avoided.
