### PR TITLE
Pana added to the list of examples of websites that use Zinnia

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,7 @@ or you can visit these websites who use Zinnia.
 * `Mauro Bianchi`_.
 * `Sergey Miracle`_.
 * `Infantium`_.
+* `Pana`_.
 
 
 If you are a proud user of Zinnia, send me the URL of your website and I
@@ -132,6 +133,7 @@ More information and help available at these URLs :
 .. _`AR.Drone Best of User Videos`: http://ardrone.parrot.com/best-of-user-videos/
 .. _`Darwin's Weblog`: http://darwin.willbreak.it/
 .. _`ShiningPanda`: http://www.shiningpanda.com/blog/
+.. _`Pana`: http://chusen87.com/news/
 .. _`Code repository`: https://github.com/Fantomas42/django-blog-zinnia
 .. _`Documentation`: http://docs.django-blog-zinnia.com/
 .. _`Jenkins CI server`: https://jenkins.shiningpanda-ci.com/django-blog-zinnia/


### PR DESCRIPTION
The zinnia powered news section of a Japanese website I recently built.
