### PR TITLE
added static context_processor to doc example

### DIFF
--- a/docs/getting-started/install.rst
+++ b/docs/getting-started/install.rst
@@ -95,6 +95,7 @@ already present. ::
     'django.core.context_processors.i18n',
     'django.core.context_processors.request',
     'django.core.context_processors.media',
+    'django.core.context_processors.static',
     'zinnia.context_processors.version',) # Optional
 
 .. _urls:


### PR DESCRIPTION
Hi,

Just trying out zinnia, i had some trouble getting it to load its staticfiles. Turns out i just needed to load  `django.core.context_processors.static` in my `settings.py` file, which was missing from the exemple given in the docs.

Just thought i'd add it there.
