### PR TITLE
Fixed error handling in comments

### DIFF
--- a/zinnia/templates/comments/zinnia_entry_preview.html
+++ b/zinnia/templates/comments/zinnia_entry_preview.html
@@ -8,6 +8,7 @@
 {% block content %}
   {% if form.errors %}
   <h2>{% blocktrans count errors=form.errors|length %}Please correct following error.{% plural %}Please correct following errors.{% endblocktrans %}</h2>
+    {{ form.errors }}
   {% else %}
   <h2>{% trans "Preview of the comment" %}</h2>
   <ol id="comment-list">


### PR DESCRIPTION
Fix: if there are errors in filling the form to submit a comment, now those errors will be actually displayed.
