### PR TITLE
Fix pollution of auth_user_model

### DIFF
--- a/zinnia/models/author.py
+++ b/zinnia/models/author.py
@@ -6,11 +6,13 @@ from django.utils.encoding import python_2_unicode_compatible
 from zinnia.managers import entries_published
 from zinnia.managers import EntryRelatedPublishedManager
 
+
 class AuthorManagers(models.Model):
     published = EntryRelatedPublishedManager()
 
     class Meta:
         abstract = True
+
 
 @python_2_unicode_compatible
 class Author(get_user_model(), AuthorManagers):

--- a/zinnia/tests/author.py
+++ b/zinnia/tests/author.py
@@ -42,7 +42,7 @@ class AuthorTestCase(TestCase):
                          'John Doe')
 
     def test_for_pollution(self):
-        self.assertEqual(get_user_model(), 
+        self.assertEqual(get_user_model(),
                          get_user_model().objects.model)
         self.assertNotEqual(get_user_model().objects.model,
                             Author)


### PR DESCRIPTION
As discussed on the mailing list, Zinnia has been polluting auth_user_model through its proxy model.

https://groups.google.com/d/msg/django-blog-zinnia/yckq6CJk7A4/peN8zcxfobsJ

This patch attempts to fix the issue by using an abstract base class as suggested in the Django documentation.

https://docs.djangoproject.com/en/dev/topics/db/models/#proxy-model-managers

Because this is an obscure issue that affects models outside of Zinnia, I'm not sure what the most appropriate test case is.
