### PR TITLE
Added dependency Django>=1.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,10 +34,12 @@ setup(
     license=zinnia.__license__,
     include_package_data=True,
     zip_safe=False,
-    install_requires=['beautifulsoup4>=4.1',
-                      'django-mptt>=0.5.1',
-                      'django-tagging>=0.3.1',
-                      'django-xmlrpc>=0.1.5',
-                      'pyparsing>=2.0.1',
-                      'pytz>=2013b']
+    install_requires=[
+        'beautifulsoup4>=4.1',
+        'Django>=1.6',
+        'django-mptt>=0.5.1',
+        'django-tagging>=0.3.1',
+        'django-xmlrpc>=0.1.5',
+        'pyparsing>=2.0.1',
+        'pytz>=2013b'],
 )


### PR DESCRIPTION
As things stand Django 1.6 is required for Zinnia now. This should be reflected in setup.py's install_requires. See issue #310
