### PR TITLE
Issue #333: Force reaction_count to integer

### DIFF
--- a/zinnia/admin/entry.py
+++ b/zinnia/admin/entry.py
@@ -84,7 +84,7 @@ class EntryAdmin(admin.ModelAdmin):
         """
         title = _('%(title)s (%(word_count)i words)') % \
             {'title': entry.title, 'word_count': entry.word_count}
-        reaction_count = (entry.comment_count +
+        reaction_count = int(entry.comment_count +
                           entry.pingback_count +
                           entry.trackback_count)
         if reaction_count:


### PR DESCRIPTION
To avoid dictionary key exceptions from ungettext_lazy method.
