### PR TITLE
Fixing excerpt gathering when excerpt is empty

### DIFF
--- a/zinnia/management/commands/wp2zinnia.py
+++ b/zinnia/management/commands/wp2zinnia.py
@@ -298,7 +298,7 @@ class Command(LabelCommand):
                 excerpt = ''
         else:
             excerpt = strip_tags(excerpt)
- 
+
         # Prefer use this function than
         # item_node.find('{%s}post_name' % WP_NS).text
         # Because slug can be not well formated


### PR DESCRIPTION
This is to fix this: 
https://github.com/Fantomas42/django-blog-zinnia/issues/296

That issue is marked as closed, but the bug still exists in the latest version.
