### PR TITLE
Migrations broken in Django 1.5?

### DIFF
--- a/zinnia/migrations/__init__.py
+++ b/zinnia/migrations/__init__.py
@@ -1,8 +1,13 @@
 """Migrations for Zinnia"""
-from django.contrib.auth import get_user_model
+try:
+    from django.contrib.auth import get_user_model
+except ImportError: # django < 1.5
+    from django.contrib.auth.models import User
+else:
+    User = get_user_model()
 
 User = get_user_model()
 user_name = User.__name__
 user_table = User._meta.db_table
 user_orm_label = '%s.%s' % (User._meta.app_label, User._meta.object_name)
-user_model_label = '%s.%s' % (User._meta.app_label, User._meta.model_name)
+user_model_label = '%s.%s' % (User._meta.app_label, User._meta.module_name)


### PR DESCRIPTION
This introduces Django 1.4 compat and fixes a problem migrating in South 1.0 + Django 1.5.x:

```
-> % python manage.py migrate --traceback
Traceback (most recent call last):
  File "local/lib/python2.7/site-packages/django/core/management/base.py", line 222, in run_from_argv
    self.execute(*args, **options.__dict__)
  File "local/lib/python2.7/site-packages/django/core/management/base.py", line 255, in execute
    output = self.handle(*args, **options)
  File "local/lib/python2.7/site-packages/south/management/commands/migrate.py", line 87, in handle
    apps = list(migration.all_migrations())
  File "local/lib/python2.7/site-packages/south/migration/base.py", line 33, in all_migrations
    yield Migrations(app)
  File "local/lib/python2.7/site-packages/south/migration/base.py", line 64, in __call__
    self.instances[app_label] = super(MigrationsMetaclass, self).__call__(app_label_to_app_module(app_label), **kwds)
  File "local/lib/python2.7/site-packages/south/migration/base.py", line 90, in __init__
    self.set_application(application, force_creation, verbose_creation)
  File "local/lib/python2.7/site-packages/south/migration/base.py", line 162, in set_application
    module = importlib.import_module(self.migrations_module())
  File "local/lib/python2.7/site-packages/django/utils/importlib.py", line 35, in import_module
    __import__(name)
  File "local/lib/python2.7/site-packages/zinnia/migrations/__init__.py", line 8, in <module>
    user_model_label = '%s.%s' % (User._meta.app_label, User._meta.model_name)
AttributeError: 'Options' object has no attribute 'model_name'
```
