### PR TITLE
Remove usage of forms.ALL_FIELDS

### DIFF
--- a/zinnia/admin/forms.py
+++ b/zinnia/admin/forms.py
@@ -46,7 +46,7 @@ class CategoryAdminForm(forms.ModelForm):
         CategoryAdminForm's Meta.
         """
         model = Category
-        fields = forms.ALL_FIELDS
+        # fields = forms.ALL_FIELDS  # Does not work in django 1.5
 
 
 class EntryAdminForm(forms.ModelForm):
@@ -71,4 +71,4 @@ class EntryAdminForm(forms.ModelForm):
         EntryAdminForm's Meta.
         """
         model = Entry
-        fields = forms.ALL_FIELDS
+        # fields = forms.ALL_FIELDS  # Does not work in django 1.5


### PR DESCRIPTION
Doesn't work in django 1.5:

```
Traceback (most recent call last):
  File "local/lib/python2.7/site-packages/django/core/handlers/base.py", line 90, in get_response
    response = middleware_method(request)
  File "local/lib/python2.7/site-packages/django/middleware/locale.py", line 21, in process_request
    check_path = self.is_language_prefix_patterns_used()
  File "local/lib/python2.7/site-packages/django/middleware/locale.py", line 56, in is_language_prefix_patterns_used
    for url_pattern in get_resolver(None).url_patterns:
  File "local/lib/python2.7/site-packages/django/core/urlresolvers.py", line 366, in url_patterns
    patterns = getattr(self.urlconf_module, "urlpatterns", self.urlconf_module)
  File "local/lib/python2.7/site-packages/django/core/urlresolvers.py", line 361, in urlconf_module
    self._urlconf_module = import_module(self.urlconf_name)
  File "local/lib/python2.7/site-packages/django/utils/importlib.py", line 35, in import_module
    __import__(name)
  File "/media/archive/documents/code/skifergas/skifergas/urls.py", line 9, in <module>
    admin.autodiscover()
  File "local/lib/python2.7/site-packages/django/contrib/admin/__init__.py", line 29, in autodiscover
    import_module('%s.admin' % app)
  File "local/lib/python2.7/site-packages/django/utils/importlib.py", line 35, in import_module
    __import__(name)
  File "local/lib/python2.7/site-packages/zinnia/admin/__init__.py", line 6, in <module>
    from zinnia.admin.entry import EntryAdmin
  File "local/lib/python2.7/site-packages/zinnia/admin/entry.py", line 25, in <module>
    from zinnia.admin.forms import EntryAdminForm
  File "local/lib/python2.7/site-packages/zinnia/admin/forms.py", line 52, in <module>
    class EntryAdminForm(forms.ModelForm):
  File "local/lib/python2.7/site-packages/zinnia/admin/forms.py", line 69, in EntryAdminForm
    class Meta:
  File "local/lib/python2.7/site-packages/zinnia/admin/forms.py", line 74, in Meta
    fields = forms.ALL_FIELDS
AttributeError: 'module' object has no attribute 'ALL_FIELDS'
```
