### PR TITLE
Add permission checking to shortlink

### DIFF
--- a/zinnia/views/shortlink.py
+++ b/zinnia/views/shortlink.py
@@ -1,11 +1,25 @@
 """Views for Zinnia shortlink"""
-from django.shortcuts import get_object_or_404
+from django.http import Http404
 from django.views.generic.base import RedirectView
+from django.utils.translation import ugettext as _
 
 from zinnia.models.entry import Entry
+from zinnia.views.mixins.entry_preview import EntryPreviewMixin
 
 
-class EntryShortLink(RedirectView):
+class EntryShortLinkMixin(object):
+    """
+    Mixin implementing the preview of Entries.
+    """
+
+    def get_object(self, queryset=None):
+        try:
+            return queryset.get()
+        except Entry.DoesNotExist:
+            raise Http404(_('No entry found matching the query'))
+
+
+class EntryShortLink(RedirectView, EntryPreviewMixin, EntryShortLinkMixin):
     """
     View for handling the shortlink of an Entry,
     simply do a redirection.
@@ -17,5 +31,6 @@ class EntryShortLink(RedirectView):
         in the 'token' variable and return the get_absolute_url
         of the entry.
         """
-        entry = get_object_or_404(Entry, pk=int(kwargs['token'], 36))
+        pk = int(kwargs['token'], 36)
+        entry = self.get_object(Entry.objects.filter(pk=pk))
         return entry.get_absolute_url()


### PR DESCRIPTION
The [redirect of a shortlink to an unpublished post](https://github.com/Fantomas42/django-blog-zinnia/blob/develop/zinnia/views/shortlink.py#L21) will redirect and result in a 404 but also leaks the URL of the post containing date and slug.

It would be better if
1. either short urls only worked on published posts (using the `EntryPublishedManager`)
2. or the `EntryPreviewMixin` check is already performed in the shortlink view.

I implemented No. 2 in this PR.
