### PR TITLE
relative instead of absolute url in screen.css

### DIFF
--- a/zinnia/static/zinnia/css/screen.css
+++ b/zinnia/static/zinnia/css/screen.css
@@ -917,10 +917,10 @@ table {
     opacity: 1; }
 .zinnia .flex-direction-nav .prev {
   left: 0;
-  background: url("/../img/prev.png") no-repeat center center; }
+  background: url("../img/prev.png") no-repeat center center; }
 .zinnia .flex-direction-nav .next {
   right: 0;
-  background: url("/../img/next.png") no-repeat center center; }
+  background: url("../img/next.png") no-repeat center center; }
 @media (min-width: 900px) {
   .zinnia .slider-container {
     padding-left: 8.43373%;


### PR DESCRIPTION
solves the following error while post-processing 'zinnia/css/screen.css':

ValueError: The file 'zinnia/prev.png' could not be found with django.contrib.staticfiles.storage.CachedStaticFilesStorage object at 0x11018b850.
