### PR TITLE
some improvements for migrations and for ZINNIA_MARKDOWN_EXTENSIONS

### DIFF
--- a/demo/models_bases.py
+++ b/demo/models_bases.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """
-A simple example of using ZINNIA_IMAGE_FILED to set Entry.image as ForeignKey to other model
+A simple example of using ZINNIA_IMAGE_FIELD to set Entry.image as ForeignKey to other model
 """
 
 from django.conf import settings
@@ -10,7 +10,7 @@ from django.utils.translation import ugettext_lazy as _
 
 if 'filer' in settings.INSTALLED_APPS:
     from filer.fields.image import FilerImageField
-    ZINNIA_IMAGE_FILED = FilerImageField(
+    ZINNIA_IMAGE_FIELD = FilerImageField(
         blank=True,
         null=True,
         related_name='entry_illustration',

--- a/demo/models_bases.py
+++ b/demo/models_bases.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+"""
+A simple example of using ZINNIA_IMAGE_FILED to set Entry.image as ForeignKey to other model
+"""
+
+from django.conf import settings
+from django.db.models import SET_NULL
+from django.utils.translation import ugettext_lazy as _
+
+if 'filer' in settings.INSTALLED_APPS:
+    from filer.fields.image import FilerImageField
+    ZINNIA_IMAGE_FILED = FilerImageField(
+        blank=True,
+        null=True,
+        related_name='entry_illustration',
+        help_text=_('Used for illustration.'),
+        db_column='image',
+        on_delete=SET_NULL,
+        default=None,)

--- a/demo/settings.py
+++ b/demo/settings.py
@@ -98,7 +98,7 @@ from zinnia.xmlrpc import ZINNIA_XMLRPC_METHODS
 XMLRPC_METHODS = ZINNIA_XMLRPC_METHODS
 
 if 'filer' in INSTALLED_APPS:
-    ZINNIA_IMAGE_FILED = 'demo.models_bases.ZINNIA_IMAGE_FILED'
+    ZINNIA_IMAGE_FIELD = 'demo.models_bases.ZINNIA_IMAGE_FIELD'
     INSTALLED_APPS += (
         'polymorphic',
         'easy_thumbnails',
@@ -113,4 +113,4 @@ if 'filer' in INSTALLED_APPS:
     )
 
 ## Otherwise, if you want, you can safely disable an image filed
-# ZINNIA_IMAGE_FILED = False
+# ZINNIA_IMAGE_FIELD = False

--- a/demo/settings.py
+++ b/demo/settings.py
@@ -90,8 +90,27 @@ INSTALLED_APPS = (
     'django_xmlrpc',
     'mptt',
     'tagging',
-    'zinnia'
+    'zinnia',
+    # 'filer',
 )
 
 from zinnia.xmlrpc import ZINNIA_XMLRPC_METHODS
 XMLRPC_METHODS = ZINNIA_XMLRPC_METHODS
+
+if 'filer' in INSTALLED_APPS:
+    ZINNIA_IMAGE_FILED = 'demo.models_bases.ZINNIA_IMAGE_FILED'
+    INSTALLED_APPS += (
+        'polymorphic',
+        'easy_thumbnails',
+    )
+    THUMBNAIL_HIGH_RESOLUTION = True
+    THUMBNAIL_PROCESSORS = (
+        'easy_thumbnails.processors.colorspace',
+        'easy_thumbnails.processors.autocrop',
+        #'easy_thumbnails.processors.scale_and_crop',
+        'filer.thumbnail_processors.scale_and_crop_with_subject_location',
+        'easy_thumbnails.processors.filters',
+    )
+
+## Otherwise, if you want, you can safely disable an image filed
+# ZINNIA_IMAGE_FILED = False

--- a/zinnia/admin/entry.py
+++ b/zinnia/admin/entry.py
@@ -29,7 +29,8 @@ class EntryAdmin(admin.ModelAdmin):
             'fields': (('title', 'status'), 'lead', 'content',)}),
         (_('Illustration'), {
             'fields': ('image', 'image_caption'),
-            'classes': ('collapse', 'collapse-closed')}),
+            'classes': ('collapse', 'collapse-closed')}) if settings.IMAGE_FILED else (
+            None, {'fields': (), 'classes': ()}),
         (_('Publication'), {
             'fields': (('start_publication', 'end_publication'),
                        'creation_date', 'sites'),

--- a/zinnia/admin/entry.py
+++ b/zinnia/admin/entry.py
@@ -29,7 +29,7 @@ class EntryAdmin(admin.ModelAdmin):
             'fields': (('title', 'status'), 'lead', 'content',)}),
         (_('Illustration'), {
             'fields': ('image', 'image_caption'),
-            'classes': ('collapse', 'collapse-closed')}) if settings.IMAGE_FILED else (
+            'classes': ('collapse', 'collapse-closed')}) if settings.IMAGE_FIELD else (
             None, {'fields': (), 'classes': ()}),
         (_('Publication'), {
             'fields': (('start_publication', 'end_publication'),

--- a/zinnia/admin/forms.py
+++ b/zinnia/admin/forms.py
@@ -79,5 +79,5 @@ class EntryAdminForm(forms.ModelForm):
             'lead': MiniTextarea,
             'excerpt': MiniTextarea,
         }
-        if settings.IMAGE_FILED:
+        if settings.IMAGE_FIELD:
             widgets.update(image_caption=MiniTextarea)

--- a/zinnia/admin/forms.py
+++ b/zinnia/admin/forms.py
@@ -13,6 +13,7 @@ from zinnia.admin.widgets import MiniTextarea
 from zinnia.admin.widgets import TagAutoComplete
 from zinnia.admin.widgets import MPTTFilteredSelectMultiple
 from zinnia.admin.fields import MPTTModelMultipleChoiceField
+from zinnia import settings
 
 
 class CategoryAdminForm(forms.ModelForm):
@@ -77,5 +78,6 @@ class EntryAdminForm(forms.ModelForm):
             'tags': TagAutoComplete,
             'lead': MiniTextarea,
             'excerpt': MiniTextarea,
-            'image_caption': MiniTextarea,
         }
+        if settings.IMAGE_FILED:
+            widgets.update(image_caption=MiniTextarea)

--- a/zinnia/feeds.py
+++ b/zinnia/feeds.py
@@ -126,7 +126,7 @@ class EntryFeed(ZinniaFeed):
         """
         Return an image for enclosure.
         """
-        if item.image:
+        if hasattr(item, 'image') and item.image:
             url = item.image.url
         else:
             img = BeautifulSoup(item.html_content).find('img')
@@ -140,7 +140,7 @@ class EntryFeed(ZinniaFeed):
         if the enclosure is present on the FS,
         otherwise returns an hardcoded value.
         """
-        if item.image:
+        if hasattr(item, 'image') and item.image:
             try:
                 return str(item.image.size)
             except (os.error, NotImplementedError):

--- a/zinnia/markups.py
+++ b/zinnia/markups.py
@@ -38,7 +38,6 @@ def markdown(value, extensions=MARKDOWN_EXTENSIONS):
                       RuntimeWarning)
         return value
 
-    extensions = [e for e in extensions.split(',') if e]
     return markdown.markdown(force_text(value),
                              extensions, safe_mode=False)
 

--- a/zinnia/migrations/0001_initial.py
+++ b/zinnia/migrations/0001_initial.py
@@ -8,7 +8,9 @@ import tagging.fields
 import zinnia.models_bases.entry
 from . import user_model_label
 
+from .. import settings
 from ..models import Entry
+from ..models_bases import load_model_class
 from ..models_bases.entry import CoreEntry, ContentEntry, \
     DiscussionsEntry, RelatedEntry, ExcerptEntry, ImageEntry, FeaturedEntry, \
     AuthorsEntry, CategoriesEntry, TagsEntry, LoginRequiredEntry, \
@@ -187,7 +189,7 @@ if issubclass(Entry, ExcerptEntry):
             help_text='Used for search and SEO.',
             verbose_name='excerpt', blank=True)))
 
-if issubclass(Entry, ImageEntry):
+if issubclass(Entry, ImageEntry) and settings.IMAGE_FILED is True:
     operations.append(migrations.AddField(
         model_name='Entry',
         name='image',
@@ -195,6 +197,11 @@ if issubclass(Entry, ImageEntry):
             help_text='Used for illustration.',
             upload_to=zinnia.models_bases.entry.image_upload_to_dispatcher,
             verbose_name='image', blank=True)))
+elif issubclass(Entry, ImageEntry) and settings.IMAGE_FILED:
+    operations.append(migrations.AddField(
+        model_name='Entry',
+        name='image',
+        field=load_model_class(settings.IMAGE_FILED)))
 
 if issubclass(Entry, FeaturedEntry):
     operations.append(migrations.AddField(

--- a/zinnia/migrations/0001_initial.py
+++ b/zinnia/migrations/0001_initial.py
@@ -6,169 +6,268 @@ import mptt.fields
 import tagging.fields
 
 import zinnia.models_bases.entry
-from zinnia.migrations import user_model_label
+from . import user_model_label
+
+from ..models import Entry
+from ..models_bases.entry import CoreEntry, ContentEntry, \
+    DiscussionsEntry, RelatedEntry, ExcerptEntry, ImageEntry, FeaturedEntry, \
+    AuthorsEntry, CategoriesEntry, TagsEntry, LoginRequiredEntry, \
+    PasswordRequiredEntry, ContentTemplateEntry, DetailTemplateEntry
+
+
+operations = [
+    migrations.CreateModel(
+        name='Category',
+        fields=[
+            ('id', models.AutoField(
+                verbose_name='ID', serialize=False,
+                auto_created=True, primary_key=True)),
+            ('title', models.CharField(
+                max_length=255, verbose_name='title')),
+            ('slug', models.SlugField(
+                help_text="Used to build the category's URL.", unique=True,
+                max_length=255, verbose_name='slug')),
+            ('description', models.TextField(
+                verbose_name='description', blank=True)),
+            ('lft', models.PositiveIntegerField(
+                editable=False, db_index=True)),
+            ('rght', models.PositiveIntegerField(
+                editable=False, db_index=True)),
+            ('tree_id', models.PositiveIntegerField(
+                editable=False, db_index=True)),
+            ('level', models.PositiveIntegerField(
+                editable=False, db_index=True)),
+            ('parent', mptt.fields.TreeForeignKey(
+                related_name='children', verbose_name='parent category',
+                blank=True, to='zinnia.Category', null=True))],
+        options={
+            'ordering': ['title'],
+            'verbose_name': 'category',
+            'verbose_name_plural': 'categories',},
+        bases=(models.Model,),),
+    migrations.CreateModel(
+        name='Author',
+        fields=[],
+        options={'proxy': True, },
+        bases=(user_model_label, models.Model)),
+    migrations.CreateModel(
+        name='Entry',
+        fields=[('id', models.AutoField(
+            verbose_name='ID', serialize=False,
+            auto_created=True, primary_key=True)),],
+            options={'abstract': False, }),
+]
+
+if issubclass(Entry, CoreEntry):
+    operations += [
+        migrations.AddField(
+            model_name='Entry',
+            name='title',
+            field=models.CharField(max_length=255, verbose_name='title')),
+        migrations.AddField(
+            model_name='Entry',
+            name='slug',
+            field=models.SlugField(
+                help_text="Used to build the entry's URL.", max_length=255,
+                verbose_name='slug', unique_for_date='creation_date')),
+        migrations.AddField(
+            model_name='Entry',
+            name='status',
+            field=models.IntegerField(
+                default=0, db_index=True, verbose_name='status',
+                choices=CoreEntry.STATUS_CHOICES)),
+        migrations.AddField(
+            model_name='Entry',
+            name='start_publication',
+            field=models.DateTimeField(
+                help_text='Start date of publication.', null=True,
+                verbose_name='start publication',
+                db_index=True, blank=True)),
+        migrations.AddField(
+            model_name='Entry',
+            name='end_publication',
+            field=models.DateTimeField(
+                help_text='End date of publication.', null=True,
+                verbose_name='end publication',
+                db_index=True, blank=True)),
+        migrations.AddField(
+            model_name='Entry',
+            name='sites',
+            field=models.ManyToManyField(
+                help_text='Sites where the entry will be published.',
+                related_name='entries', verbose_name='sites',
+                to='sites.Site')),
+        migrations.AddField(
+            model_name='Entry',
+            name='creation_date',
+            field=models.DateTimeField(
+                default=django.utils.timezone.now,
+                help_text="Used to build the entry's URL.",
+                verbose_name='creation date', db_index=True)),
+        migrations.AddField(
+            model_name='Entry',
+            name='last_update',
+            field=models.DateTimeField(
+                default=django.utils.timezone.now,
+                verbose_name='last update')),
+        migrations.AlterModelOptions(
+            name='Entry',
+            options={
+                'get_latest_by': 'creation_date',
+                'ordering': ['-creation_date'],
+                'verbose_name_plural': 'entries',
+                'verbose_name': 'entry',
+                'permissions': (('can_view_all', 'Can view all entries'),
+                                ('can_change_status', 'Can change status'),
+                                ('can_change_author', 'Can change author(s)')), },
+        ),
+        migrations.AlterIndexTogether(
+            name='Entry',
+            index_together={
+                ('status', 'creation_date', 'start_publication', 'end_publication'),
+                ('slug', 'creation_date')}),
+    ]
+
+if issubclass(Entry, ContentEntry):
+    operations.append(migrations.AddField(
+        model_name='Entry',
+        name='content',
+        field=models.TextField(verbose_name='content', blank=True),))
+
+if issubclass(Entry, DiscussionsEntry):
+    operations += [
+        migrations.AddField(
+            model_name='Entry',
+            name='comment_enabled',
+            field=models.BooleanField(
+                default=True, help_text='Allows comments if checked.',
+                verbose_name='comments enabled')),
+        migrations.AddField(
+            model_name='Entry',
+            name='pingback_enabled',
+            field=models.BooleanField(
+                default=True, help_text='Allows pingbacks if checked.',
+                verbose_name='pingbacks enabled')),
+        migrations.AddField(
+            model_name='Entry',
+            name='trackback_enabled',
+            field=models.BooleanField(
+                default=True, help_text='Allows trackbacks if checked.',
+                verbose_name='trackbacks enabled')),
+        migrations.AddField(
+            model_name='Entry',
+            name='comment_count',
+            field=models.IntegerField(default=0, verbose_name='comment count')),
+        migrations.AddField(
+            model_name='Entry',
+            name='pingback_count',
+            field=models.IntegerField(
+                default=0, verbose_name='pingback count')),
+        migrations.AddField(
+            model_name='Entry',
+            name='trackback_count',
+            field=models.IntegerField(
+                default=0, verbose_name='trackback count')),
+    ]
+
+if issubclass(Entry, RelatedEntry):
+    operations.append(migrations.AddField(
+        model_name='Entry',
+        name='related',
+        field=models.ManyToManyField(
+            related_name='related_rel_+', null=True,
+            verbose_name='related entries', to='zinnia.Entry',
+            blank=True)))
+
+if issubclass(Entry, ExcerptEntry):
+    operations.append(migrations.AddField(
+        model_name='Entry',
+        name='excerpt',
+        field=models.TextField(
+            help_text='Used for search and SEO.',
+            verbose_name='excerpt', blank=True)))
+
+if issubclass(Entry, ImageEntry):
+    operations.append(migrations.AddField(
+        model_name='Entry',
+        name='image',
+        field=models.ImageField(
+            help_text='Used for illustration.',
+            upload_to=zinnia.models_bases.entry.image_upload_to_dispatcher,
+            verbose_name='image', blank=True)))
+
+if issubclass(Entry, FeaturedEntry):
+    operations.append(migrations.AddField(
+        model_name='Entry',
+        name='featured',
+        field=models.BooleanField(default=False, verbose_name='featured')))
+
+if issubclass(Entry, AuthorsEntry):
+    operations.append(migrations.AddField(
+        model_name='Entry',
+        name='authors',
+        field=models.ManyToManyField(
+            related_name='entries', verbose_name='authors',
+            to='zinnia.Author', blank=True),
+        preserve_default=True))
+
+if issubclass(Entry, CategoriesEntry):
+    operations.append(migrations.AddField(
+        model_name='Entry',
+        name='categories',
+        field=models.ManyToManyField(
+            related_name='entries', null=True,
+            verbose_name='categories', to='zinnia.Category',
+            blank=True)))
+
+if issubclass(Entry, TagsEntry):
+    operations.append(migrations.AddField(
+        model_name='Entry',
+        name='tags',
+        field=tagging.fields.TagField(
+            max_length=255, verbose_name='tags', blank=True)))
+
+if issubclass(Entry, LoginRequiredEntry):
+    operations.append(migrations.AddField(
+        model_name='Entry',
+        name='login_required',
+        field=models.BooleanField(
+            default=False, verbose_name='login required',
+            help_text='Only authenticated users can view the entry.')))
+
+if issubclass(Entry, PasswordRequiredEntry):
+    operations.append(migrations.AddField(
+        model_name='Entry',
+        name='password',
+        field=models.CharField(
+            help_text='Protects the entry with a password.',
+            max_length=50, verbose_name='password', blank=True)))
+
+if issubclass(Entry, ContentTemplateEntry):
+    operations.append(migrations.AddField(
+        model_name='Entry',
+        name='content_template',
+        field=models.CharField(
+            default='zinnia/_entry_detail.html',
+            help_text="Template used to display the entry's content.",
+            max_length=250, verbose_name='content template',
+            choices=[('zinnia/_entry_detail.html', 'Default template')])))
+
+if issubclass(Entry, DetailTemplateEntry):
+    operations.append(migrations.AddField(
+        model_name='Entry',
+        name='detail_template',
+        field=models.CharField(
+            default='entry_detail.html',
+            help_text="Template used to display the entry's detail page.",
+            max_length=250, verbose_name='detail template',
+            choices=[('entry_detail.html', 'Default template')])))
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('auth', '0001_initial'),
         ('sites', '0001_initial'),
     ]
 
-    operations = [
-        migrations.CreateModel(
-            name='Category',
-            fields=[
-                ('id', models.AutoField(
-                    verbose_name='ID', serialize=False,
-                    auto_created=True, primary_key=True)),
-                ('title', models.CharField(
-                    max_length=255, verbose_name='title')),
-                ('slug', models.SlugField(
-                    help_text="Used to build the category's URL.", unique=True,
-                    max_length=255, verbose_name='slug')),
-                ('description', models.TextField(
-                    verbose_name='description', blank=True)),
-                ('lft', models.PositiveIntegerField(
-                    editable=False, db_index=True)),
-                ('rght', models.PositiveIntegerField(
-                    editable=False, db_index=True)),
-                ('tree_id', models.PositiveIntegerField(
-                    editable=False, db_index=True)),
-                ('level', models.PositiveIntegerField(
-                    editable=False, db_index=True)),
-                ('parent', mptt.fields.TreeForeignKey(
-                    related_name='children', verbose_name='parent category',
-                    blank=True, to='zinnia.Category', null=True)),
-            ],
-            options={
-                'ordering': ['title'],
-                'verbose_name': 'category',
-                'verbose_name_plural': 'categories',
-            },
-            bases=(models.Model,),
-        ),
-        migrations.CreateModel(
-            name='Entry',
-            fields=[
-                ('id', models.AutoField(
-                    verbose_name='ID', serialize=False,
-                    auto_created=True, primary_key=True)),
-                ('title', models.CharField(
-                    max_length=255, verbose_name='title')),
-                ('slug', models.SlugField(
-                    help_text="Used to build the entry's URL.", max_length=255,
-                    verbose_name='slug', unique_for_date='creation_date')),
-                ('status', models.IntegerField(
-                    default=0, db_index=True, verbose_name='status',
-                    choices=[(0, 'draft'), (1, 'hidden'), (2, 'published')])),
-                ('start_publication', models.DateTimeField(
-                    help_text='Start date of publication.', null=True,
-                    verbose_name='start publication',
-                    db_index=True, blank=True)),
-                ('end_publication', models.DateTimeField(
-                    help_text='End date of publication.', null=True,
-                    verbose_name='end publication',
-                    db_index=True, blank=True)),
-                ('creation_date', models.DateTimeField(
-                    default=django.utils.timezone.now,
-                    help_text="Used to build the entry's URL.",
-                    verbose_name='creation date', db_index=True)),
-                ('last_update', models.DateTimeField(
-                    default=django.utils.timezone.now,
-                    verbose_name='last update')),
-                ('content', models.TextField(
-                    verbose_name='content', blank=True)),
-                ('comment_enabled', models.BooleanField(
-                    default=True, help_text='Allows comments if checked.',
-                    verbose_name='comments enabled')),
-                ('pingback_enabled', models.BooleanField(
-                    default=True, help_text='Allows pingbacks if checked.',
-                    verbose_name='pingbacks enabled')),
-                ('trackback_enabled', models.BooleanField(
-                    default=True, help_text='Allows trackbacks if checked.',
-                    verbose_name='trackbacks enabled')),
-                ('comment_count', models.IntegerField(
-                    default=0, verbose_name='comment count')),
-                ('pingback_count', models.IntegerField(
-                    default=0, verbose_name='pingback count')),
-                ('trackback_count', models.IntegerField(
-                    default=0, verbose_name='trackback count')),
-                ('excerpt', models.TextField(
-                    help_text='Used for search and SEO.',
-                    verbose_name='excerpt', blank=True)),
-                ('image', models.ImageField(
-                    help_text='Used for illustration.',
-                    upload_to=zinnia.models_bases.entry.image_upload_to_dispatcher,  # noqa
-                    verbose_name='image', blank=True)),
-                ('featured', models.BooleanField(
-                    default=False, verbose_name='featured')),
-                ('tags', tagging.fields.TagField(
-                    max_length=255, verbose_name='tags', blank=True)),
-                ('login_required', models.BooleanField(
-                    default=False, verbose_name='login required',
-                    help_text='Only authenticated users can view the entry.')),
-                ('password', models.CharField(
-                    help_text='Protects the entry with a password.',
-                    max_length=50, verbose_name='password', blank=True)),
-                ('content_template', models.CharField(
-                    default='zinnia/_entry_detail.html',
-                    help_text="Template used to display the entry's content.",
-                    max_length=250, verbose_name='content template',
-                    choices=[('zinnia/_entry_detail.html',
-                              'Default template')])),
-                ('detail_template', models.CharField(
-                    default='entry_detail.html',
-                    help_text="Template used to display the entry's detail page.",  # noqa
-                    max_length=250, verbose_name='detail template',
-                    choices=[('entry_detail.html', 'Default template')])),
-                ('categories', models.ManyToManyField(
-                    related_name='entries', null=True,
-                    verbose_name='categories', to='zinnia.Category',
-                    blank=True)),
-                ('related', models.ManyToManyField(
-                    related_name='related_rel_+', null=True,
-                    verbose_name='related entries', to='zinnia.Entry',
-                    blank=True)),
-                ('sites', models.ManyToManyField(
-                    help_text='Sites where the entry will be published.',
-                    related_name='entries', verbose_name='sites',
-                    to='sites.Site')),
-            ],
-            options={
-                'get_latest_by': 'creation_date',
-                'ordering': ['-creation_date'],
-                'abstract': False,
-                'verbose_name_plural': 'entries',
-                'verbose_name': 'entry',
-                'permissions': (('can_view_all', 'Can view all entries'),
-                                ('can_change_status', 'Can change status'),
-                                ('can_change_author', 'Can change author(s)')),
-            },
-            bases=(models.Model,),
-        ),
-        migrations.CreateModel(
-            name='Author',
-            fields=[
-            ],
-            options={
-                'proxy': True,
-            },
-            bases=(user_model_label, models.Model),
-        ),
-        migrations.AddField(
-            model_name='entry',
-            name='authors',
-            field=models.ManyToManyField(
-                related_name='entries', verbose_name='authors',
-                to='zinnia.Author', blank=True),
-            preserve_default=True,
-        ),
-        migrations.AlterIndexTogether(
-            name='entry',
-            index_together=set([('status', 'creation_date',
-                                 'start_publication', 'end_publication'),
-                                ('slug', 'creation_date')]),
-        ),
-    ]
+    operations = operations

--- a/zinnia/migrations/0001_initial.py
+++ b/zinnia/migrations/0001_initial.py
@@ -189,7 +189,7 @@ if issubclass(Entry, ExcerptEntry):
             help_text='Used for search and SEO.',
             verbose_name='excerpt', blank=True)))
 
-if issubclass(Entry, ImageEntry) and settings.IMAGE_FILED is True:
+if issubclass(Entry, ImageEntry) and settings.IMAGE_FIELD is True:
     operations.append(migrations.AddField(
         model_name='Entry',
         name='image',
@@ -197,11 +197,11 @@ if issubclass(Entry, ImageEntry) and settings.IMAGE_FILED is True:
             help_text='Used for illustration.',
             upload_to=zinnia.models_bases.entry.image_upload_to_dispatcher,
             verbose_name='image', blank=True)))
-elif issubclass(Entry, ImageEntry) and settings.IMAGE_FILED:
+elif issubclass(Entry, ImageEntry) and settings.IMAGE_FIELD:
     operations.append(migrations.AddField(
         model_name='Entry',
         name='image',
-        field=load_model_class(settings.IMAGE_FILED)))
+        field=load_model_class(settings.IMAGE_FIELD)))
 
 if issubclass(Entry, FeaturedEntry):
     operations.append(migrations.AddField(

--- a/zinnia/migrations/0002_lead_paragraph_and_image_caption.py
+++ b/zinnia/migrations/0002_lead_paragraph_and_image_caption.py
@@ -3,9 +3,11 @@ from django.db import migrations
 
 from ..models import Entry
 from ..models_bases.entry import LeadEntry, ImageEntry
+from .. import settings
 
 operations = []
-if issubclass(Entry, ImageEntry):
+
+if issubclass(Entry, ImageEntry) and settings.IMAGE_FILED:
     operations.append(migrations.AddField(
         model_name='entry',
         name='image_caption',
@@ -13,6 +15,7 @@ if issubclass(Entry, ImageEntry):
             default='', help_text="Image's caption",
             verbose_name='caption', blank=True),
         preserve_default=False,))
+
 if issubclass(Entry, LeadEntry):
     operations.append(migrations.AddField(
         model_name='entry',

--- a/zinnia/migrations/0002_lead_paragraph_and_image_caption.py
+++ b/zinnia/migrations/0002_lead_paragraph_and_image_caption.py
@@ -1,28 +1,31 @@
 from django.db import models
 from django.db import migrations
 
+from ..models import Entry
+from ..models_bases.entry import LeadEntry, ImageEntry
+
+operations = []
+if issubclass(Entry, ImageEntry):
+    operations.append(migrations.AddField(
+        model_name='entry',
+        name='image_caption',
+        field=models.TextField(
+            default='', help_text="Image's caption",
+            verbose_name='caption', blank=True),
+        preserve_default=False,))
+if issubclass(Entry, LeadEntry):
+    operations.append(migrations.AddField(
+        model_name='entry',
+        name='lead',
+        field=models.TextField(
+            default='', help_text='Lead paragraph',
+            verbose_name='lead', blank=True),
+        preserve_default=False))
+
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('zinnia', '0001_initial'),
     ]
 
-    operations = [
-        migrations.AddField(
-            model_name='entry',
-            name='image_caption',
-            field=models.TextField(
-                default='', help_text="Image's caption",
-                verbose_name='caption', blank=True),
-            preserve_default=False,
-        ),
-        migrations.AddField(
-            model_name='entry',
-            name='lead',
-            field=models.TextField(
-                default='', help_text='Lead paragraph',
-                verbose_name='lead', blank=True),
-            preserve_default=False,
-        ),
-    ]
+    operations = operations

--- a/zinnia/migrations/0002_lead_paragraph_and_image_caption.py
+++ b/zinnia/migrations/0002_lead_paragraph_and_image_caption.py
@@ -7,7 +7,7 @@ from .. import settings
 
 operations = []
 
-if issubclass(Entry, ImageEntry) and settings.IMAGE_FILED:
+if issubclass(Entry, ImageEntry) and settings.IMAGE_FIELD:
     operations.append(migrations.AddField(
         model_name='entry',
         name='image_caption',

--- a/zinnia/models_bases/__init__.py
+++ b/zinnia/models_bases/__init__.py
@@ -7,7 +7,7 @@ def load_model_class(model_path):
     """
     Load by import a class by a string path like:
     'module.models.MyModel'.
-    This mecanizm allows extension and customization of
+    This mechanism allows extension and customization of
     the Entry model class.
     """
     dot = model_path.rindex('.')

--- a/zinnia/models_bases/entry.py
+++ b/zinnia/models_bases/entry.py
@@ -11,6 +11,7 @@ from django.contrib.sites.models import Site
 from django.template.defaultfilters import slugify
 from django.utils.translation import ugettext_lazy as _
 from django.utils.encoding import python_2_unicode_compatible
+from . import load_model_class
 
 import django_comments as comments
 from django_comments.models import CommentFlag
@@ -24,6 +25,7 @@ from zinnia.markups import restructuredtext
 from zinnia.preview import HTMLPreview
 from zinnia.flags import PINGBACK, TRACKBACK
 from zinnia.settings import UPLOAD_TO
+from zinnia.settings import IMAGE_FILED
 from zinnia.settings import MARKUP_LANGUAGE
 from zinnia.settings import ENTRY_DETAIL_TEMPLATES
 from zinnia.settings import ENTRY_CONTENT_TEMPLATES
@@ -420,28 +422,32 @@ class ImageEntry(models.Model):
     Abstract model class to add an image for illustrating the entries.
     """
 
-    def image_upload_to(self, filename):
-        """
-        Compute the upload path for the image field.
-        """
-        now = timezone.now()
-        filename, extension = os.path.splitext(filename)
+    if IMAGE_FILED is True:
+        def image_upload_to(self, filename):
+            """
+            Compute the upload path for the image field.
+            """
+            now = timezone.now()
+            filename, extension = os.path.splitext(filename)
 
-        return os.path.join(
-            UPLOAD_TO,
-            now.strftime('%Y'),
-            now.strftime('%m'),
-            now.strftime('%d'),
-            '%s%s' % (slugify(filename), extension))
+            return os.path.join(
+                UPLOAD_TO,
+                now.strftime('%Y'),
+                now.strftime('%m'),
+                now.strftime('%d'),
+                '%s%s' % (slugify(filename), extension))
 
-    image = models.ImageField(
-        _('image'), blank=True,
-        upload_to=image_upload_to_dispatcher,
-        help_text=_('Used for illustration.'))
+        image = models.ImageField(
+            _('image'), blank=True,
+            upload_to=image_upload_to_dispatcher,
+            help_text=_('Used for illustration.'))
+    elif IMAGE_FILED:
+        image = load_model_class(IMAGE_FILED)
 
-    image_caption = models.TextField(
-        _('caption'), blank=True,
-        help_text=_("Image's caption."))
+    if IMAGE_FILED:
+        image_caption = models.TextField(
+            _('caption'), blank=True,
+            help_text=_("Image's caption."))
 
     class Meta:
         abstract = True

--- a/zinnia/models_bases/entry.py
+++ b/zinnia/models_bases/entry.py
@@ -25,7 +25,7 @@ from zinnia.markups import restructuredtext
 from zinnia.preview import HTMLPreview
 from zinnia.flags import PINGBACK, TRACKBACK
 from zinnia.settings import UPLOAD_TO
-from zinnia.settings import IMAGE_FILED
+from zinnia.settings import IMAGE_FIELD
 from zinnia.settings import MARKUP_LANGUAGE
 from zinnia.settings import ENTRY_DETAIL_TEMPLATES
 from zinnia.settings import ENTRY_CONTENT_TEMPLATES
@@ -422,7 +422,7 @@ class ImageEntry(models.Model):
     Abstract model class to add an image for illustrating the entries.
     """
 
-    if IMAGE_FILED is True:
+    if IMAGE_FIELD is True:
         def image_upload_to(self, filename):
             """
             Compute the upload path for the image field.
@@ -441,10 +441,10 @@ class ImageEntry(models.Model):
             _('image'), blank=True,
             upload_to=image_upload_to_dispatcher,
             help_text=_('Used for illustration.'))
-    elif IMAGE_FILED:
-        image = load_model_class(IMAGE_FILED)
+    elif IMAGE_FIELD:
+        image = load_model_class(IMAGE_FIELD)
 
-    if IMAGE_FILED:
+    if IMAGE_FIELD:
         image_caption = models.TextField(
             _('caption'), blank=True,
             help_text=_("Image's caption."))

--- a/zinnia/settings.py
+++ b/zinnia/settings.py
@@ -1,5 +1,6 @@
 """Settings of Zinnia"""
 from django.conf import settings
+from django.utils import six
 
 PING_DIRECTORIES = getattr(settings, 'ZINNIA_PING_DIRECTORIES',
                            ('http://django-blog-zinnia.com/xmlrpc/',))
@@ -25,7 +26,11 @@ ENTRY_CONTENT_TEMPLATES = getattr(
 
 MARKUP_LANGUAGE = getattr(settings, 'ZINNIA_MARKUP_LANGUAGE', 'html')
 
-MARKDOWN_EXTENSIONS = getattr(settings, 'ZINNIA_MARKDOWN_EXTENSIONS', '')
+MARKDOWN_EXTENSIONS = getattr(settings, 'ZINNIA_MARKDOWN_EXTENSIONS',
+    getattr(settings, 'MARKDOWN_EXTENSIONS', []))
+
+if isinstance(MARKDOWN_EXTENSIONS, six.string_types):
+    MARKDOWN_EXTENSIONS = [e for e in MARKDOWN_EXTENSIONS.split(',') if e]
 
 RESTRUCTUREDTEXT_SETTINGS = getattr(
     settings, 'ZINNIA_RESTRUCTUREDTEXT_SETTINGS', {})

--- a/zinnia/settings.py
+++ b/zinnia/settings.py
@@ -66,7 +66,7 @@ COMMENT_MIN_WORDS = getattr(settings, 'ZINNIA_COMMENT_MIN_WORDS', 4)
 
 COMMENT_FLAG_USER_ID = getattr(settings, 'ZINNIA_COMMENT_FLAG_USER_ID', 1)
 
-IMAGE_FILED = getattr(settings, 'ZINNIA_IMAGE_FILED', True)
+IMAGE_FIELD = getattr(settings, 'ZINNIA_IMAGE_FIELD', True)
 
 UPLOAD_TO = getattr(settings, 'ZINNIA_UPLOAD_TO', 'uploads/zinnia')
 
@@ -83,11 +83,11 @@ F_MAX = getattr(settings, 'ZINNIA_F_MAX', 1.0)
 
 SEARCH_FIELDS = getattr(settings, 'ZINNIA_SEARCH_FIELDS',
                         ['title', 'lead', 'content', 'excerpt'] + \
-                        ([ 'image_caption'] if IMAGE_FILED else []))
+                        ([ 'image_caption'] if IMAGE_FIELD else []))
 
 COMPARISON_FIELDS = getattr(settings, 'ZINNIA_COMPARISON_FIELDS',
                             ['title', 'lead', 'content', 'excerpt'] + \
-                            ([ 'image_caption'] if IMAGE_FILED else []))
+                            ([ 'image_caption'] if IMAGE_FIELD else []))
 
 SPAM_CHECKER_BACKENDS = getattr(settings, 'ZINNIA_SPAM_CHECKER_BACKENDS',
                                 ())

--- a/zinnia/settings.py
+++ b/zinnia/settings.py
@@ -61,6 +61,8 @@ COMMENT_MIN_WORDS = getattr(settings, 'ZINNIA_COMMENT_MIN_WORDS', 4)
 
 COMMENT_FLAG_USER_ID = getattr(settings, 'ZINNIA_COMMENT_FLAG_USER_ID', 1)
 
+IMAGE_FILED = getattr(settings, 'ZINNIA_IMAGE_FILED', True)
+
 UPLOAD_TO = getattr(settings, 'ZINNIA_UPLOAD_TO', 'uploads/zinnia')
 
 PROTOCOL = getattr(settings, 'ZINNIA_PROTOCOL', 'http')
@@ -75,12 +77,12 @@ F_MIN = getattr(settings, 'ZINNIA_F_MIN', 0.1)
 F_MAX = getattr(settings, 'ZINNIA_F_MAX', 1.0)
 
 SEARCH_FIELDS = getattr(settings, 'ZINNIA_SEARCH_FIELDS',
-                        ['title', 'lead', 'content',
-                         'excerpt', 'image_caption'])
+                        ['title', 'lead', 'content', 'excerpt'] + \
+                        ([ 'image_caption'] if IMAGE_FILED else []))
 
 COMPARISON_FIELDS = getattr(settings, 'ZINNIA_COMPARISON_FIELDS',
-                            ['title', 'lead', 'content',
-                             'excerpt', 'image_caption'])
+                            ['title', 'lead', 'content', 'excerpt'] + \
+                            ([ 'image_caption'] if IMAGE_FILED else []))
 
 SPAM_CHECKER_BACKENDS = getattr(settings, 'ZINNIA_SPAM_CHECKER_BACKENDS',
                                 ())

--- a/zinnia/tests/test_markups.py
+++ b/zinnia/tests/test_markups.py
@@ -34,7 +34,7 @@ class MarkupsTestCase(TestCase):
         self.assertEqual(markdown(text).strip(),
                          '<p>[TOC]</p>\n<h1>Header 1</h1>'
                          '\n<h2>Header 2</h2>')
-        self.assertEqual(markdown(text, extensions='toc').strip(),
+        self.assertEqual(markdown(text, extensions=['toc']).strip(),
                          '<div class="toc">\n<ul>\n<li><a href="#header-1">'
                          'Header 1</a><ul>\n<li><a href="#header-2">'
                          'Header 2</a></li>\n</ul>\n</li>\n</ul>\n</div>'

--- a/zinnia/xmlrpc/__init__.py
+++ b/zinnia/xmlrpc/__init__.py
@@ -1,5 +1,6 @@
 """XML-RPC methods for Zinnia"""
 
+from .. import settings
 
 ZINNIA_XMLRPC_PINGBACK = [
     ('zinnia.xmlrpc.pingback.pingback_ping',
@@ -29,8 +30,7 @@ ZINNIA_XMLRPC_METAWEBLOG = [
     ('zinnia.xmlrpc.metaweblog.new_post',
      'metaWeblog.newPost'),
     ('zinnia.xmlrpc.metaweblog.edit_post',
-     'metaWeblog.editPost'),
-    ('zinnia.xmlrpc.metaweblog.new_media_object',
-     'metaWeblog.newMediaObject')]
+     'metaWeblog.editPost')] + ([('zinnia.xmlrpc.metaweblog.new_media_object',
+     'metaWeblog.newMediaObject')] if settings.IMAGE_FILED is True else [])
 
 ZINNIA_XMLRPC_METHODS = ZINNIA_XMLRPC_PINGBACK + ZINNIA_XMLRPC_METAWEBLOG

--- a/zinnia/xmlrpc/__init__.py
+++ b/zinnia/xmlrpc/__init__.py
@@ -31,6 +31,6 @@ ZINNIA_XMLRPC_METAWEBLOG = [
      'metaWeblog.newPost'),
     ('zinnia.xmlrpc.metaweblog.edit_post',
      'metaWeblog.editPost')] + ([('zinnia.xmlrpc.metaweblog.new_media_object',
-     'metaWeblog.newMediaObject')] if settings.IMAGE_FILED is True else [])
+     'metaWeblog.newMediaObject')] if settings.IMAGE_FIELD is True else [])
 
 ZINNIA_XMLRPC_METHODS = ZINNIA_XMLRPC_PINGBACK + ZINNIA_XMLRPC_METAWEBLOG


### PR DESCRIPTION
1. you can use ZINNIA_ENTRY_BASE_MODEL for determine your own model of Entry. But migration is trying to create a model of AbstractEntry. I tried to fix this problem.
1. I think such a definition of ImageEntry.image field would be better
1. I think use the list of modules (or names) while setting options is an better idea than the join this list to one big string, and then split them (for ZINNIA_MARKDOWN_EXTENSIONS)
