### PR TITLE
Fix issue #411

### DIFF
--- a/zinnia/admin/forms.py
+++ b/zinnia/admin/forms.py
@@ -1,7 +1,6 @@
 """Forms for Zinnia admin"""
 from django import forms
 from django.db.models import ManyToOneRel
-from django.db.models import ManyToManyRel
 from django.utils.translation import ugettext_lazy as _
 from django.contrib.admin.widgets import RelatedFieldWidgetWrapper
 
@@ -60,12 +59,6 @@ class EntryAdminForm(forms.ModelForm):
         queryset=Category.objects.all(),
         widget=MPTTFilteredSelectMultiple(_('categories'), False,
                                           attrs={'rows': '10'}))
-
-    def __init__(self, *args, **kwargs):
-        super(EntryAdminForm, self).__init__(*args, **kwargs)
-        rel = ManyToManyRel(Category, 'id')
-        self.fields['categories'].widget = RelatedFieldWidgetWrapper(
-            self.fields['categories'].widget, rel, self.admin_site)
 
     class Meta:
         """


### PR DESCRIPTION
Add the operation proposed by @datakid at https://github.com/Fantomas42/django-blog-zinnia/issues/411#issuecomment-91975548

This patch is usable and the ``categories`` field have the same look and usage than the demo: http://demo.django-blog-zinnia.com/admin/zinnia/entry/1/

