### PR TITLE
use json for tag list in entry admin

### DIFF
--- a/zinnia/admin/widgets.py
+++ b/zinnia/admin/widgets.py
@@ -1,5 +1,6 @@
 """Widgets for Zinnia admin"""
 from itertools import chain
+import json
 
 from django.utils import six
 from django.forms import Media
@@ -91,8 +92,7 @@ class TagAutoComplete(widgets.AdminTextInputWidget):
         output.append('       width: "element",')
         output.append('       maximumInputLength: 50,')
         output.append('       tokenSeparators: [",", " "],')
-        output.append('       tags: [%s]' % ','.join(
-            ["'%s'" % tag for tag in self.get_tags()]))
+        output.append('       tags: %s' % json.dumps(self.get_tags()))
         output.append('     });')
         output.append('    });')
         output.append('}(django.jQuery));')


### PR DESCRIPTION
If your tags have certain characters, you'll get a javascript error because it will parse the array incorrectly. 

For example, if you have the following tags: `apple, dog's, flower`
the result of the original implementation would be `['apple', 'dog's', 'flower']`

the apostrophe in `dog's` breaks the array. Using JSON will allow for proper format.