### PR TITLE
reduce number of entries in admin to improve page load

### DIFF
--- a/zinnia/admin/entry.py
+++ b/zinnia/admin/entry.py
@@ -66,6 +66,7 @@ class EntryAdmin(admin.ModelAdmin):
                'mark_featured', 'unmark_featured']
     actions_on_top = True
     actions_on_bottom = True
+    list_per_page = 20
 
     def __init__(self, model, admin_site):
         self.form.admin_site = admin_site


### PR DESCRIPTION
Page load times for us are really slow. Limiting paginatino to 20 entries really helps and I don't think most people need to see the default 100 at a time anyways.