### PR TITLE
Fixed redirection as permanent

### DIFF
--- a/zinnia/urls/shortlink.py
+++ b/zinnia/urls/shortlink.py
@@ -8,6 +8,6 @@ from zinnia.views.shortlink import EntryShortLink
 urlpatterns = patterns(
     '',
     url(r'^(?P<token>[\dA-Z]+)/$',
-        EntryShortLink.as_view(),
+        EntryShortLink.as_view(permanent=True),
         name='entry_shortlink'),
 )


### PR DESCRIPTION
Django 1.8 raises this warning:
/Library/Python/2.7/site-packages/zinnia/urls/shortlink.py:11: RemovedInDjango19Warning: Default value of 'RedirectView.permanent' will change from True to False in Django 1.9. Set an explicit value to silence this warning.

I made it !