### PR TITLE
Admin: patch XSS by escaping output of allow_tags functions

### DIFF
--- a/zinnia/admin/category.py
+++ b/zinnia/admin/category.py
@@ -1,6 +1,7 @@
 """CategoryAdmin for Zinnia"""
 from django.contrib import admin
 from django.core.urlresolvers import NoReverseMatch
+from django.utils.html import format_html
 from django.utils.translation import ugettext_lazy as _
 
 from zinnia.admin.forms import CategoryAdminForm
@@ -26,8 +27,8 @@ class CategoryAdmin(admin.ModelAdmin):
         Return the category's tree path in HTML.
         """
         try:
-            return '<a href="%s" target="blank">/%s/</a>' % \
-                   (category.get_absolute_url(), category.tree_path)
+            return format_html('<a href="{}" target="blank">/{}/</a>',
+                               category.get_absolute_url(), category.tree_path)
         except NoReverseMatch:
             return '/%s/' % category.tree_path
     get_tree_path.allow_tags = True

--- a/zinnia/admin/entry.py
+++ b/zinnia/admin/entry.py
@@ -5,6 +5,7 @@ from django.utils import timezone
 from django.contrib.sites.models import Site
 from django.core.urlresolvers import reverse
 from django.core.urlresolvers import NoReverseMatch
+from django.utils.html import format_html, conditional_escape
 from django.utils.translation import ungettext_lazy
 from django.utils.translation import ugettext_lazy as _
 
@@ -94,12 +95,13 @@ class EntryAdmin(admin.ModelAdmin):
         Return the authors in HTML.
         """
         try:
-            authors = ['<a href="%s" target="blank">%s</a>' %
-                       (author.get_absolute_url(),
-                        getattr(author, author.USERNAME_FIELD))
+            authors = [format_html('<a href="{}" target="blank">{}</a>',
+                                   author.get_absolute_url(),
+                                   getattr(author, author.USERNAME_FIELD))
                        for author in entry.authors.all()]
         except NoReverseMatch:
-            authors = [getattr(author, author.USERNAME_FIELD)
+            authors = [conditional_escape(getattr(author,
+                                                  author.USERNAME_FIELD))
                        for author in entry.authors.all()]
         return ', '.join(authors)
     get_authors.allow_tags = True
@@ -110,12 +112,13 @@ class EntryAdmin(admin.ModelAdmin):
         Return the categories linked in HTML.
         """
         try:
-            categories = ['<a href="%s" target="blank">%s</a>' %
-                          (category.get_absolute_url(), category.title)
+            categories = [format_html('<a href="{}" target="blank">{}</a>',
+                                      category.get_absolute_url(),
+                                      category.title)
                           for category in entry.categories.all()]
         except NoReverseMatch:
-            categories = [category.title for category in
-                          entry.categories.all()]
+            categories = [conditional_escape(category.title)
+                          for category in entry.categories.all()]
         return ', '.join(categories)
     get_categories.allow_tags = True
     get_categories.short_description = _('category(s)')
@@ -125,11 +128,13 @@ class EntryAdmin(admin.ModelAdmin):
         Return the tags linked in HTML.
         """
         try:
-            return ', '.join(['<a href="%s" target="blank">%s</a>' %
-                              (reverse('zinnia:tag_detail', args=[tag]), tag)
+            return ', '.join([format_html('<a href="{}" target="blank">{}</a>',
+                                          reverse('zinnia:tag_detail',
+                                                  args=[tag]),
+                                          tag)
                               for tag in entry.tags_list])
         except NoReverseMatch:
-            return entry.tags
+            return conditional_escape(entry.tags)
     get_tags.allow_tags = True
     get_tags.short_description = _('tag(s)')
 
@@ -143,7 +148,8 @@ class EntryAdmin(admin.ModelAdmin):
             index_url = ''
         return ', '.join(
             ['<a href="%s://%s%s" target="blank">%s</a>' %
-             (settings.PROTOCOL, site.domain, index_url, site.name)
+             (settings.PROTOCOL, site.domain, index_url,
+              conditional_escape(site.name))
              for site in entry.sites.all()])
     get_sites.allow_tags = True
     get_sites.short_description = _('site(s)')
@@ -156,8 +162,8 @@ class EntryAdmin(admin.ModelAdmin):
             short_url = entry.short_url
         except NoReverseMatch:
             short_url = entry.get_absolute_url()
-        return '<a href="%(url)s" target="blank">%(url)s</a>' % \
-               {'url': short_url}
+        return format_html('<a href="{url}" target="blank">{url}</a>',
+                           url=short_url)
     get_short_url.allow_tags = True
     get_short_url.short_description = _('short url')
 

--- a/zinnia/tests/test_admin.py
+++ b/zinnia/tests/test_admin.py
@@ -94,7 +94,7 @@ class EntryAdminTestCase(BaseAdminTestCase):
         author_1 = Author.objects.create_user(
             'author-1', 'author1@example.com')
         author_2 = Author.objects.create_user(
-            'author-2', 'author2@example.com')
+            'author<2>', 'author2@example.com')
         self.entry.authors.add(author_1)
         self.check_with_rich_and_poor_urls(
             self.admin.get_authors, (self.entry,),
@@ -104,8 +104,9 @@ class EntryAdminTestCase(BaseAdminTestCase):
         self.check_with_rich_and_poor_urls(
             self.admin.get_authors, (self.entry,),
             '<a href="/authors/author-1/" target="blank">author-1</a>, '
-            '<a href="/authors/author-2/" target="blank">author-2</a>',
-            'author-1, author-2',)
+            '<a href="/authors/author%3C2%3E/" target="blank">'
+            'author&lt;2&gt;</a>',
+            'author-1, author&lt;2&gt;',)
 
     def test_get_categories(self):
         self.check_with_rich_and_poor_urls(
@@ -113,7 +114,7 @@ class EntryAdminTestCase(BaseAdminTestCase):
             '', '')
         category_1 = Category.objects.create(title='Category 1',
                                              slug='category-1')
-        category_2 = Category.objects.create(title='Category 2',
+        category_2 = Category.objects.create(title='Category <b>2</b>',
                                              slug='category-2')
         self.entry.categories.add(category_1)
         self.check_with_rich_and_poor_urls(
@@ -124,8 +125,9 @@ class EntryAdminTestCase(BaseAdminTestCase):
         self.check_with_rich_and_poor_urls(
             self.admin.get_categories, (self.entry,),
             '<a href="/categories/category-1/" target="blank">Category 1</a>, '
-            '<a href="/categories/category-2/" target="blank">Category 2</a>',
-            'Category 1, Category 2')
+            '<a href="/categories/category-2/" target="blank">Category '
+            '&lt;b&gt;2&lt;/b&gt;</a>',
+            'Category 1, Category &lt;b&gt;2&lt;/b&gt;')
 
     def test_get_tags(self):
         self.check_with_rich_and_poor_urls(
@@ -136,12 +138,12 @@ class EntryAdminTestCase(BaseAdminTestCase):
             self.admin.get_tags, (self.entry,),
             '<a href="/tags/zinnia/" target="blank">zinnia</a>',
             'zinnia')
-        self.entry.tags = 'zinnia, test'
+        self.entry.tags = 'zinnia, t<e>st'
         self.check_with_rich_and_poor_urls(
             self.admin.get_tags, (self.entry,),
-            '<a href="/tags/test/" target="blank">test</a>, '
+            '<a href="/tags/t%3Ce%3Est/" target="blank">t&lt;e&gt;st</a>, '
             '<a href="/tags/zinnia/" target="blank">zinnia</a>',
-            'zinnia, test')  # Yes, this is not the same order...
+            'zinnia, t&lt;e&gt;st')  # Yes, this is not the same order...
 
     def test_get_sites(self):
         self.assertEqual(self.admin.get_sites(self.entry), '')


### PR DESCRIPTION
There are multiple XSS in the admin because the listing uses `allow_tags = True` custom functions that return unescaped HTML. This patch includes the corresponding tests, which pass using `./bin/test`.

Even though these data are usually admin or staff-controlled, it would display weird stuff if there are non-malicious `<` or `>` symbols in the category/slug/username/tag/url. Django provides a very nice `format_html` method that handles everything automatically, it would be a shame not to use it.