### PR TITLE
Remove reference to "privacy" for base 36 encoding [develop]

### DIFF
--- a/docs/topics/url_shortener.rst
+++ b/docs/topics/url_shortener.rst
@@ -21,8 +21,8 @@ entries shorter, example:
 
   http://mydomain.com/blog/2S/
 
-This backend use the primary key of the entries, encoded in base 36 for
-more privacy.
+This backend use the primary key of the entries, encoded in base 36 to
+save a few more characters.
 
 Of course the URL is short (and can be shorter) but if you have a long
 domain, the URL can be not so short, example:


### PR DESCRIPTION
Base 36 encoding the entry ID gives no privacy whatsoever as it's not a hashing function. The only way of not being able to retrieve the original ID – without bruteforcing – would be to use a [hashids](http://hashids.org/)-like transformation.

---
*Copy of #446 on the right branch.*