### PR TITLE
Calculate unicode punctuation dictionary lazily

### DIFF
--- a/zinnia/comparison.py
+++ b/zinnia/comparison.py
@@ -15,10 +15,17 @@ from zinnia.settings import STOP_WORDS
 from zinnia.settings import COMPARISON_FIELDS
 
 
-PUNCTUATION = dict.fromkeys(
-    i for i in range(sys.maxunicode)
-    if unicodedata.category(six.unichr(i)).startswith('P')
-)
+_punctuation = None
+
+
+def get_punctuation():
+    global _punctuation
+    if _punctuation is None:
+        _punctuation = dict.fromkeys(
+            i for i in range(sys.maxunicode)
+            if unicodedata.category(six.unichr(i)).startswith('P')
+        )
+    return _punctuation
 
 
 def pearson_score(list1, list2):
@@ -106,9 +113,9 @@ class ModelVectorBuilder(object):
         """
         Apply a cleaning on raw datas.
         """
-        datas = strip_tags(datas)             # Remove HTML
-        datas = STOP_WORDS.rebase(datas, '')  # Remove STOP WORDS
-        datas = datas.translate(PUNCTUATION)  # Remove punctuation
+        datas = strip_tags(datas)                   # Remove HTML
+        datas = STOP_WORDS.rebase(datas, '')        # Remove STOP WORDS
+        datas = datas.translate(get_punctuation())  # Remove punctuation
         datas = datas.lower()
         return [d for d in datas.split() if len(d) > 1]
 


### PR DESCRIPTION
Whilst profiling my app I found that this loop over all unicode characters was
taking up to half a second of startup time. This is a high tax for just
installing Zinnia, since it affects every test run etc.

A quick timeit shows it takes 386ms - however it's slower in our dev
environment which is in a VM in Vagrant:

```
In [7]: %timeit PUNCTUATION = dict.fromkeys(i for i in range(sys.maxunicode) if unicodedata.category(six.unichr(i)).startswith('P') )
1 loops, best of 3: 386 ms per loop
```

It can be calculated once on-demand, obviating the need for the high
computation cost to be paid at import time. However this does mean that the
first time it's called in a process it will be slow.

An alternative would be to install the `regex` library which can replace
unicode characters by their class (see
http://stackoverflow.com/a/11066687/1427135) - however I wasn't sure if adding
another dependency would be worth it.