### PR TITLE
fix enclosure

### DIFF
--- a/zinnia/feeds.py
+++ b/zinnia/feeds.py
@@ -131,7 +131,8 @@ class EntryFeed(ZinniaFeed):
         else:
             img = BeautifulSoup(item.html_content, 'html.parser').find('img')
             if img:
-                url = img.get('src').replace("https://", "http://")
+                url = img.get('src')
+                url = url.replace("https://", "http://") if url else None
             else:
                 url = None
         self.cached_enclosure_url = url

--- a/zinnia/feeds.py
+++ b/zinnia/feeds.py
@@ -130,7 +130,10 @@ class EntryFeed(ZinniaFeed):
             url = item.image.url.replace("https://", "http://")
         else:
             img = BeautifulSoup(item.html_content, 'html.parser').find('img')
-            url = img.get('src').replace("https://", "http://") if img else None
+            if img:
+                url = img.get('src').replace("https://", "http://")
+            else:
+                url = None
         self.cached_enclosure_url = url
         return urljoin(self.site_url, url) if url else None
 

--- a/zinnia/feeds.py
+++ b/zinnia/feeds.py
@@ -127,10 +127,10 @@ class EntryFeed(ZinniaFeed):
         Return an image for enclosure.
         """
         if item.image:
-            url = item.image.url
+            url = item.image.url.replace("https://", "http://")
         else:
             img = BeautifulSoup(item.html_content, 'html.parser').find('img')
-            url = img.get('src') if img else None
+            url = img.get('src').replace("https://", "http://") if img else None
         self.cached_enclosure_url = url
         return urljoin(self.site_url, url) if url else None
 

--- a/zinnia/tests/test_feeds.py
+++ b/zinnia/tests/test_feeds.py
@@ -162,6 +162,23 @@ class FeedsTestCase(TestCase):
         self.assertEqual(feed.item_enclosure_length(entry), '100000')
         self.assertEqual(feed.item_enclosure_mime_type(entry), 'image/jpeg')
 
+    def test_entry_feed_enclosure_replace_https(self):
+        entry = self.create_published_entry()
+        feed = EntryFeed()
+        entry.content = 'My test content with image in https ' \
+                        '<img src="https://test.com/image.jpg" />'
+        entry.save()
+        self.assertEqual(
+            feed.item_enclosure_url(entry), 'http://test.com/image.jpg')
+
+    def test_entry_feed_enclosure_without_image(self):
+        entry = self.create_published_entry()
+        feed = EntryFeed()
+        entry.content = 'My test content without image '
+        entry.save()
+        self.assertEqual(
+            feed.item_enclosure_url(entry), None)
+
     def test_entry_feed_enclosure_issue_134(self):
         entry = self.create_published_entry()
         feed = EntryFeed()


### PR DESCRIPTION
according to RSS 2.0 spec (see here: http://www.rssboard.org/rss-specification#ltenclosuregtSubelementOfLtitemgt),
the enclosure tag accepts only a http url and the feed does not validate with a https one

Tested with https://validator.w3.org/feed/, the validator return an error "url must be a full URL" when the enclosure has a https image inside its url.