### PR TITLE
Use namespace='zinnia' in documentation

### DIFF
--- a/docs/getting-started/install.rst
+++ b/docs/getting-started/install.rst
@@ -116,7 +116,7 @@ URLs
 Add at least these following lines to your project's urls.py in order to
 display the Weblog. ::
 
-  url(r'^weblog/', include('zinnia.urls', namespace='polls')),
+  url(r'^weblog/', include('zinnia.urls', namespace='zinnia')),
   url(r'^comments/', include('django_comments.urls')),
 
 Remember to enable the :mod:`~django.contrib.admin` site in the urls.py of

--- a/docs/getting-started/install.rst
+++ b/docs/getting-started/install.rst
@@ -116,7 +116,7 @@ URLs
 Add at least these following lines to your project's urls.py in order to
 display the Weblog. ::
 
-  url(r'^weblog/', include('zinnia.urls')),
+  url(r'^weblog/', include('zinnia.urls', namespace='polls')),
   url(r'^comments/', include('django_comments.urls')),
 
 Remember to enable the :mod:`~django.contrib.admin` site in the urls.py of


### PR DESCRIPTION
Or else I get:
 
    'zinnia' is not a registered namespace 

PS: I'm a Django newb, maybe this makes no sense.
