### PR TITLE
Translate breacrumbs root_name properly

### DIFF
--- a/zinnia/templatetags/zinnia.py
+++ b/zinnia/templatetags/zinnia.py
@@ -14,7 +14,7 @@ from django.utils import timezone
 from django.template import Library
 from django.utils.encoding import smart_text
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 from django.utils.html import conditional_escape
 from django.template.loader import select_template
 from django.template.defaultfilters import stringfilter


### PR DESCRIPTION
Please review my changes.

I see there was a try to fix it, but it doesn't work out for me:
https://github.com/Fantomas42/django-blog-zinnia/pull/322
Because the `root_name` is translated during the application start. To make it work, we should do the lazy translation.