### PR TITLE
Modernize documentation on sitemaps

### DIFF
--- a/docs/getting-started/configuration.rst
+++ b/docs/getting-started/configuration.rst
@@ -16,22 +16,19 @@ these steps.
 * Register :mod:`django.contrib.sitemaps` in the :setting:`INSTALLED_APPS` section.
 * Edit your project's URLs and add this code: ::
 
-   from zinnia.sitemaps import TagSitemap
-   from zinnia.sitemaps import EntrySitemap
-   from zinnia.sitemaps import CategorySitemap
-   from zinnia.sitemaps import AuthorSitemap
-
-   sitemaps = {'tags': TagSitemap,
-               'blog': EntrySitemap,
-               'authors': AuthorSitemap,
-               'categories': CategorySitemap,}
-
-   urlpatterns += patterns(
-       'django.contrib.sitemaps.views',
-       url(r'^sitemap.xml$', 'index',
-           {'sitemaps': sitemaps}),
-       url(r'^sitemap-(?P<section>.+)\.xml$', 'sitemap',
-           {'sitemaps': sitemaps}),)
+from django.contrib.sitemaps.views import sitemap
+from zinnia.sitemaps import TagSitemap
+from zinnia.sitemaps import EntrySitemap
+from zinnia.sitemaps import CategorySitemap
+from zinnia.sitemaps import AuthorSitemap
+sitemaps = {'tags': TagSitemap,
+            'blog': EntrySitemap,
+            'authors': AuthorSitemap,
+            'categories': CategorySitemap,}
+urlpatterns += [
+        url(r'^sitemap\.xml$', sitemap, {'sitemaps': sitemaps},
+            name='django.contrib.sitemaps.views.sitemap'),
+    ]
 
 .. _zinnia-templates:
 


### PR DESCRIPTION
The previous documentation on Zinnia support for sitemaps used the old patterns function for URL handling.


# What is the purpose of your *pull request*?

 - [X ] Bug fix

# Proposed changes

This pull request replaces that example with code that works on Django 1.10.

# Warning

Before submitting a *pull request* make sure you have:

 - [ ] Wrote some tests.
 - [ ] Respected the [PEP 8](https://www.python.org/dev/peps/pep-0008).
 - [ ] Read the guidelines for contributing linked to above.

I don't see anything in the guidelines for contributing that apply to documentation improvements.