### PR TITLE
add doc line for importing django.donf.urls.include

### DIFF
--- a/docs/getting-started/install.rst
+++ b/docs/getting-started/install.rst
@@ -112,8 +112,11 @@ already present. ::
 
 URLs
 ====
+In your project's urls.py, add this line if it is not already there ::
 
-Add at least these following lines to your project's urls.py in order to
+  from django.conf.urls import include
+
+Then, add at least these following lines in order to
 display the Weblog. ::
 
   url(r'^weblog/', include('zinnia.urls')),


### PR DESCRIPTION
# What is the purpose of your *pull request*?

 - [X] Bug fix
 - [ ] New feature

# Proposed changes
Simple addition to the documentation. The import statement may eliminate a small stumbling block for people new to django. It is not added by default as of Django 1.11, though I believe it once was.

There's no code changing here, though I appreciate that this project adheres to PEP 8.

# Warning

Before submitting a *pull request* make sure you have:

 - [X] Read the guidelines for contributing.
 - [X] Wrote some tests.
 - [X] Respected the [PEP 8](https://www.python.org/dev/peps/pep-0008).
