### PR TITLE
Fix get User model for cookiecutter-django

### DIFF
--- a/zinnia/models/author.py
+++ b/zinnia/models/author.py
@@ -2,10 +2,9 @@
 from django.apps import apps
 from django.conf import settings
 from django.db import models
-from django.urls import reverse
 from django.contrib.auth import get_user_model
+from django.urls import reverse
 from django.utils.encoding import python_2_unicode_compatible
-
 
 from zinnia.managers import EntryRelatedPublishedManager
 from zinnia.managers import entries_published

--- a/zinnia/models/author.py
+++ b/zinnia/models/author.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.db import models
 from django.urls import reverse
 from django.utils.encoding import python_2_unicode_compatible
+from django.contrib.auth import get_user_model
 
 from zinnia.managers import EntryRelatedPublishedManager
 from zinnia.managers import entries_published
@@ -13,8 +14,9 @@ def safe_get_user_model():
     """
     Safe loading of the User model, customized or not.
     """
-    user_app, user_model = settings.AUTH_USER_MODEL.split('.')
-    return apps.get_registered_model(user_app, user_model)
+    # user_app, user_model = settings.AUTH_USER_MODEL.split('.')
+    # return apps.get_registered_model(user_app, user_model)
+    return get_user_model()
 
 
 class AuthorPublishedManager(models.Model):

--- a/zinnia/models/author.py
+++ b/zinnia/models/author.py
@@ -3,8 +3,9 @@ from django.apps import apps
 from django.conf import settings
 from django.db import models
 from django.urls import reverse
-from django.utils.encoding import python_2_unicode_compatible
 from django.contrib.auth import get_user_model
+from django.utils.encoding import python_2_unicode_compatible
+
 
 from zinnia.managers import EntryRelatedPublishedManager
 from zinnia.managers import entries_published

--- a/zinnia/models/author.py
+++ b/zinnia/models/author.py
@@ -1,8 +1,8 @@
 """Author model for Zinnia"""
 from django.apps import apps
 from django.conf import settings
-from django.db import models
 from django.contrib.auth import get_user_model
+from django.db import models
 from django.urls import reverse
 from django.utils.encoding import python_2_unicode_compatible
 


### PR DESCRIPTION
This change fixes issue Can't migrate database on fresh install with cookiecutter-django. #537, opened by flaviobarros. This way, User model is allways notified right using Django Auth system.

<!--

Have you read the contributing guidelines ?

https://github.com/Fantomas42/django-blog-zinnia/blob/develop/.github/CONTRIBUTING.md

-->
# What is the purpose of your *pull request*?

 - [X] Bug fix
 - [ ] New feature

# Proposed changes


# Warning

<!--

Please read these points carefully and answer honestly with an `X`
into all the boxes. Example : [X]

-->

Before submitting a *pull request* make sure you have:

 - [X] Read the guidelines for contributing.
 - [ ] Wrote some tests.
 - [X] Respected the [PEP 8](https://www.python.org/dev/peps/pep-0008).

I didn't write any test but main zinnia tests pass al OK.