### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/how-to/customize_look_and_feel.rst
+++ b/docs/how-to/customize_look_and_feel.rst
@@ -42,7 +42,7 @@ CSS customizations
 ------------------
 
 Most of the time the customization process of Zinnia is about editing the
-cascading style sheet of the differents pages delivered by the Weblog.
+cascading style sheet of the different pages delivered by the Weblog.
 
 First of all you have to note that each page of the Weblog has several
 classes applied on the ``<body>`` markup. For examples if the document has
@@ -216,7 +216,7 @@ Each entries of the Weblog has the possibility to have his own template to
 be rendered by using the :setting:`ZINNIA_ENTRY_DETAIL_TEMPLATES` settings, so
 with this option you can handle multiple presentation for your entries. And
 because :class:`~zinnia.views.entries.EntryDetail` is based on an archive
-view a custom list of templates is built uppon the publication date.
+view a custom list of templates is built upon the publication date.
 The entry's slug is also used to build the template list for having
 maximal customization capabilities with ease.
 

--- a/docs/how-to/rewriting_entry_url.rst
+++ b/docs/how-to/rewriting_entry_url.rst
@@ -105,7 +105,7 @@ To do this override, simply use the method explained in the
           abstract = True
 
 Due to the intensive use of this method into the templates, make sure that
-your re-implemention is not too slow. For example hitting the database to
+your re-implementation is not too slow. For example hitting the database to
 recontruct this URL is not a really good idea. That's why an URL pattern
 based on the categories like ``/blog/<category-1>/<category-n>/<slug>/`` is
 really bad.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@ Django-Blog-Zinnia's documentation!
 
 Welcome to the version |version| of the documentation.
 
-You can also find the differents editions of the
+You can also find the different editions of the
 `documentation online at readthedocs.org`_.
 
 .. toctree::

--- a/docs/notes/faq.rst
+++ b/docs/notes/faq.rst
@@ -24,7 +24,7 @@ I want to have multilingual support on the entries, is it possible ?
 --------------------------------------------------------------------
 
 Due to the extending capabilities of Zinnia, many solutions on this
-problematic are possible, but you must keep in mind that multiplingual
+problematic are possible, but you must keep in mind that multilingual
 entries is just a concept, the needs and the implementations can differ
 from a project to another. But you should take a look on this excellent
 tutorial to `convert Zinnia into a multilingual Weblog`_ with

--- a/zinnia/markups.py
+++ b/zinnia/markups.py
@@ -46,7 +46,7 @@ def markdown(value, extensions=MARKDOWN_EXTENSIONS):
 
 def restructuredtext(value, settings=RESTRUCTUREDTEXT_SETTINGS):
     """
-    RestructuredText processing with optionnally custom settings.
+    RestructuredText processing with optionally custom settings.
     """
     try:
         from docutils.core import publish_parts

--- a/zinnia/models/entry.py
+++ b/zinnia/models/entry.py
@@ -5,5 +5,5 @@ from zinnia.settings import ENTRY_BASE_MODEL
 
 class Entry(load_model_class(ENTRY_BASE_MODEL)):
     """
-    The final Entry model based on inheritence.
+    The final Entry model based on inheritance.
     """

--- a/zinnia/models_bases/entry.py
+++ b/zinnia/models_bases/entry.py
@@ -333,7 +333,7 @@ class DiscussionsEntry(models.Model):
 class RelatedEntry(models.Model):
     """
     Abstract model class for making manual relations
-    between the differents entries.
+    between the different entries.
     """
     related = models.ManyToManyField(
         'self',
@@ -569,7 +569,7 @@ class AbstractEntry(
     all the abstract entry model classes into a single one.
 
     In this manner we can override some fields without
-    reimplemting all the AbstractEntry.
+    reimplementing all the AbstractEntry.
     """
 
     class Meta(CoreEntry.Meta):

--- a/zinnia/static/zinnia/admin/dashboard/js/masonry.pkgd.js
+++ b/zinnia/static/zinnia/admin/dashboard/js/masonry.pkgd.js
@@ -2004,7 +2004,7 @@ Outlayer.prototype.layout = function() {
     this.options.isLayoutInstant : !this._isLayoutInited;
   this.layoutItems( this.items, isInstant );
 
-  // flag for initalized
+  // flag for initialized
   this._isLayoutInited = true;
 };
 

--- a/zinnia/views/mixins/entry_protection.py
+++ b/zinnia/views/mixins/entry_protection.py
@@ -4,7 +4,7 @@ from django.contrib.auth.views import LoginView
 
 class LoginMixin(object):
     """
-    Mixin implemeting a login view
+    Mixin implementing a login view
     configurated for Zinnia.
     """
 


### PR DESCRIPTION
There are small typos in:
- docs/how-to/customize_look_and_feel.rst
- docs/how-to/rewriting_entry_url.rst
- docs/index.rst
- docs/notes/faq.rst
- zinnia/markups.py
- zinnia/models/entry.py
- zinnia/models_bases/entry.py
- zinnia/static/zinnia/admin/dashboard/js/masonry.pkgd.js
- zinnia/views/mixins/entry_protection.py

Fixes:
- Should read `different` rather than `differents`.
- Should read `upon` rather than `uppon`.
- Should read `reimplementing` rather than `reimplemting`.
- Should read `optionally` rather than `optionnally`.
- Should read `multilingual` rather than `multiplingual`.
- Should read `initialized` rather than `initalized`.
- Should read `inheritance` rather than `inheritence`.
- Should read `implementing` rather than `implemeting`.
- Should read `implementation` rather than `implemention`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md